### PR TITLE
Frontend: Download orange line cars from Flask

### DIFF
--- a/elm/elm.json
+++ b/elm/elm.json
@@ -6,12 +6,16 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
-            "elm/html": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3"
         },
         "indirect": {
-            "elm/json": "1.1.3",
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.4",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"

--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -6,10 +6,21 @@ import Html exposing (Html)
 
 main =
     Browser.sandbox
-        { init = { vehicles = [] }
+        { init = { vehicles = vehicles }
         , view = view
         , update = update
         }
+
+
+vehicles : List Vehicle
+vehicles =
+    [ { label = "1241"
+      , route = "Orange"
+      , currentStatus = StoppedAt
+      , stationId = "place-ogmnl"
+      , newFlag = False
+      }
+    ]
 
 
 type alias Model =
@@ -40,6 +51,15 @@ update msg model =
     model
 
 
+renderVehicle : Vehicle -> Html Msg
+renderVehicle vehicle =
+    Html.text (Debug.toString vehicle)
+
+
 view : Model -> Html Msg
 view model =
-    Html.text "Hello world"
+    Html.div []
+        [ Html.text "Vehicles:"
+        , Html.ul []
+            (List.map renderVehicle model.vehicles)
+        ]

--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -6,14 +6,29 @@ import Html exposing (Html)
 
 main =
     Browser.sandbox
-        { init = {}
+        { init = { vehicles = [] }
         , view = view
         , update = update
         }
 
 
 type alias Model =
-    {}
+    { vehicles : List Vehicle
+    }
+
+
+type alias Vehicle =
+    { label : String
+    , route : String
+    , currentStatus : CurrentStatus
+    , stationId : String
+    , newFlag : Bool
+    }
+
+
+type CurrentStatus
+    = InTransitTo
+    | StoppedAt
 
 
 type Msg

--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -4,12 +4,23 @@ import Browser
 import Html exposing (Html)
 
 
+main : Program Flags Model Msg
 main =
-    Browser.sandbox
-        { init = { vehicles = vehicles }
+    Browser.element
+        { init =
+            \_ ->
+                ( { vehicles = vehicles
+                  }
+                , Cmd.none
+                )
         , view = view
         , update = update
+        , subscriptions = \_ -> Sub.none
         }
+
+
+type alias Flags =
+    {}
 
 
 vehicles : List Vehicle
@@ -46,9 +57,11 @@ type Msg
     = NoOp
 
 
-update : Msg -> Model -> Model
+update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    model
+    ( model
+    , Cmd.none
+    )
 
 
 renderVehicle : Vehicle -> Html Msg

--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -7,23 +7,49 @@ import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipeline
 
 
+type alias Flags =
+    {}
+
+
+type alias Model =
+    { vehicles : List Vehicle
+    }
+
+
+type Msg
+    = ReceiveVehicles (Result Http.Error (List Vehicle))
+
+
+type alias Vehicle =
+    { label : String
+    , route : String
+    , currentStatus : CurrentStatus
+    , stationId : String
+    , newFlag : Bool
+    }
+
+
+type CurrentStatus
+    = InTransitTo
+    | StoppedAt
+
+
 main : Program Flags Model Msg
 main =
     Browser.element
-        { init =
-            \_ ->
-                ( { vehicles = []
-                  }
-                , getNewVehicles
-                )
+        { init = init
         , view = view
         , update = update
         , subscriptions = \_ -> Sub.none
         }
 
 
-type alias Flags =
-    {}
+init : flags -> ( Model, Cmd Msg )
+init _ =
+    ( { vehicles = []
+      }
+    , getNewVehicles
+    )
 
 
 getNewVehicles : Cmd Msg
@@ -61,29 +87,6 @@ vehicleDecoder =
         |> Pipeline.required "new_flag" Decode.bool
 
 
-type alias Model =
-    { vehicles : List Vehicle
-    }
-
-
-type alias Vehicle =
-    { label : String
-    , route : String
-    , currentStatus : CurrentStatus
-    , stationId : String
-    , newFlag : Bool
-    }
-
-
-type CurrentStatus
-    = InTransitTo
-    | StoppedAt
-
-
-type Msg
-    = ReceiveVehicles (Result Http.Error (List Vehicle))
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -104,17 +107,17 @@ update msg model =
                     )
 
 
-renderVehicle : Vehicle -> Html Msg
-renderVehicle vehicle =
-    Html.li []
-        [ Html.text (Debug.toString vehicle)
-        ]
-
-
 view : Model -> Html Msg
 view model =
     Html.div []
         [ Html.text "Vehicles:"
         , Html.ul []
             (List.map renderVehicle model.vehicles)
+        ]
+
+
+renderVehicle : Vehicle -> Html Msg
+renderVehicle vehicle =
+    Html.li []
+        [ Html.text (Debug.toString vehicle)
         ]


### PR DESCRIPTION
This change allows the Elm side to download Orange line cars from Flask. Renders them initially as an html list.

Thanks @skyqrose for the help!