### PR TITLE
Change routes endpoint to support multiple routes

### DIFF
--- a/server/MbtaApi.py
+++ b/server/MbtaApi.py
@@ -12,10 +12,10 @@ def getV3(command, params={}, api_key=secrets.API_KEY):
     response = requests.get(BASE_URL_V3.format(command=command, parameters=urlencode(params)), headers=headers)
     return json_api_doc.parse(response.json())
 
-def vehicle_data_for_route(route):
-    """Use getv3 to request real-time vehicle data for a given route string"""
+def vehicle_data_for_routes(routes):
+    """Use getv3 to request real-time vehicle data for a given route set"""
     vehicles = getV3('vehicles', {
-        'filter[route]': route,
+        'filter[route]': ','.join(routes),
         'include': 'stop'
     })
 

--- a/server/server.py
+++ b/server/server.py
@@ -17,9 +17,9 @@ def js(filename):
     return flask.send_from_directory("../js", filename)
 
 # Data routes
-@app.route("/data/Orange")
-def data_orange():
-    return flask.Response(json.dumps(MbtaApi.vehicle_data_for_route('Orange')))
+@app.route("/data/<routes>")
+def data(routes):
+    return flask.Response(json.dumps(MbtaApi.vehicle_data_for_routes(routes.split(','))))
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
Previously, only /data/Orange was supported—this change enables data from multiple lines to be downloaded at one time. /data/Orange still works.

i.e. GET /data/[Comma separated route list]