### PR TITLE
Link the TM logo to TM homepage

### DIFF
--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -157,11 +157,10 @@ view : Model -> Html Msg
 view model =
     Html.div
         []
-        [ header,
-        Html.div [Html.class "container"]
-            [
-                banner,
-                viewLadder model
+        [ header
+        , Html.div [ Html.class "container" ]
+            [ banner
+            , viewLadder model
             ]
         , footer model.vehicles
         ]
@@ -310,12 +309,16 @@ footer remoteVehicles =
     Html.div
         [ Html.class "footer" ]
         [ Html.text numNewTrainsText
-        , Html.img
-            [ Html.class "footer-wordmark"
-            , Html.src "/assets/TM_wordmark.svg"
-            , Html.alt "Transit Matters"
+        , Html.a
+            [ Html.href "https://transitmatters.org/"
             ]
-            []
+            [ Html.img
+                [ Html.class "footer-wordmark"
+                , Html.src "/assets/TM_wordmark.svg"
+                , Html.alt "Transit Matters"
+                ]
+                []
+            ]
         ]
 
 


### PR DESCRIPTION
The TM logo in the bottom right corner now links to https://transitmatters.org

<img width="279" alt="image" src="https://user-images.githubusercontent.com/193453/73123989-e71d7100-3f63-11ea-9042-4e4a5bb54add.png">
