### PR TITLE
Handle errors better.

### DIFF
--- a/elm/src/Helpers.elm
+++ b/elm/src/Helpers.elm
@@ -1,0 +1,18 @@
+module Helpers exposing (robustListDecoder)
+
+import Json.Decode as Decode exposing (Decoder)
+
+
+{-| Discards any elements that fail to decode.
+-}
+robustListDecoder : Decoder a -> Decoder (List a)
+robustListDecoder elemDecoder =
+    Decode.value
+        -- Decoder Decode.Value
+        |> Decode.map (Decode.decodeValue elemDecoder)
+        -- Decoder (Result x a)
+        |> Decode.map Result.toMaybe
+        -- Decoder (Maybe a)
+        |> Decode.list
+        -- Decoder (List (Maybe a))
+        |> Decode.map (List.filterMap identity)

--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -204,13 +204,8 @@ viewLadder model =
             ( _, RemoteData.Loading ) ->
                 [ Html.text "Loading" ]
 
-            ( error_stops, error_vehicles ) ->
-                [ Html.text "Error"
-                , Html.text "Stops:"
-                , Html.text (Debug.toString error_stops)
-                , Html.text "Vehicles:"
-                , Html.text (Debug.toString error_vehicles)
-                ]
+            ( _, _ ) ->
+                [ Html.text "Something went wrong. Try reloading." ]
         )
 
 

--- a/elm/src/Main.elm
+++ b/elm/src/Main.elm
@@ -2,6 +2,7 @@ module Main exposing (main)
 
 import Browser
 import Data exposing (..)
+import Helpers
 import Html exposing (Html)
 import Html.Attributes as Html
 import Http
@@ -62,7 +63,7 @@ getNewVehicles =
         , expect =
             Http.expectJson
                 (ReceiveVehicles << RemoteData.fromResult)
-                (Decode.list vehicleDecoder)
+                (Helpers.robustListDecoder vehicleDecoder)
         }
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "cd server && pipenv install",
-    "build-elm": "cd elm && elm make src/Main.elm --output ../js/elm.js",
+    "build-elm-prod": "cd elm && elm make src/Main.elm --output ../js/elm.js --optimize",
     "build-elm-debug": "cd elm && elm make src/Main.elm --output ../js/elm.js --debug",
     "watch-elm": "npm run build-elm-debug; chokidar elm/src/ -c 'npm run build-elm-debug'",
     "start-python": "cd server && pipenv run python3 application.py",


### PR DESCRIPTION
If there's a vehicle with missing data that we don't know how to handle, ignore that vehicle, and keep showing the other vehicles. (Instead of breaking the app.)

On other errors, like network errors, show a friendlier message.

Adds the --optimize flag which does some small optimizations like shortening variable names, and preventing us from accidentally pushing debug statements to prod. Info on minifying/optimizing the output is in the [official elm docs](https://guide.elm-lang.org/optimization/asset_size.html)