### PR TITLE
Added Python and Javascript linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: lint
+
+on: pull_request
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Lint with Flake8
+        run: |
+          pip install flake8
+          flake8 --ignore=E501,E731 server
+
+  javascipt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up Node 12.13.0
+        uses: actions/setup-node@v1
+        with:
+            node-version: 12.13.0
+      - name: Lint with ESLint
+        run:
+          npm install eslint
+          npx eslint src
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # New Train Tracker
+![](https://github.com/transitmatters/new-train-tracker/workflows/lint/badge.svg)
 
 Developed by [TransitMatters](transitmatters.org)
 

--- a/server/MbtaApi.py
+++ b/server/MbtaApi.py
@@ -5,7 +5,6 @@ import json
 import os
 import aiohttp
 import secrets
-import time
 import tempfile
 
 import Fleet


### PR DESCRIPTION
- Added GitHub Actions workflow for linting Python files in `server/` and JS files in `src/` (note this will only run on Pull Requests)
- Added lint status badge to `README.md`
- Remove unused dependency from `MbtaApi.py`