### PR TITLE
add server deployment config files

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 flask = "*"
 json-api-doc = "*"
 aiohttp = "*"
+gunicorn = "*"
 
 [requires]
 python_version = "3.8"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,27 @@ Run:
 - visit [http://localhost:5000/](http://localhost:5000/)
 
 To use an API key, put it in `server/secrets.py` or as an environment variable `MBTA_V3_API_KEY`
+
+## Server Deployment
+
+Additional requirements:
+- nginx
+- supervisord
+
+Nginx serves as a reverse-proxy for the app running on localhost:5001.
+The Flask app is being run under gunicorn, and this process is controlled by supervisor, which will restart after failure or reboot automatically. (Supervisor is similar to systemd in this regard)
+
+For a fresh deploy:
+
+- Copy devops/tracker-nginx.conf to /etc/nginx/sites-enabled. Probably restart nginx (`sudo systemctl restart nginx`)
+- Copy devops/tracker-supervisor.conf to /etc/supervisor/conf.d
+- Run `pipenv install`
+- Run `npm run build`
+- Run `sudo supervisorctl reload`
+
+To deploy changes:
+
+- If supervisor/nginx conf files changed, copy them to those directories and restart services accordingly.
+- If Pipfile has changed, run `pipenv update`. (N.B. If the source of a package has changed, you may have to manually run `pipenv run pip uninstall ____` before updating so the old one is removed)
+- `npm run build`
+- `sudo supervisorctl restart new-train-tracker`

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The Flask app is being run under gunicorn, and this process is controlled by sup
 
 For a fresh deploy:
 
-- Copy devops/tracker-nginx.conf to /etc/nginx/sites-enabled. Probably restart nginx (`sudo systemctl restart nginx`)
-- Copy devops/tracker-supervisor.conf to /etc/supervisor/conf.d
+- Copy `devops/tracker-nginx.conf` into `/etc/nginx/sites-enabled/`. Probably restart nginx (`sudo systemctl restart nginx`)
+- Copy `devops/tracker-supervisor.conf` into `/etc/supervisor/conf.d/`
 - Run `pipenv install`
 - Run `npm run build`
 - Run `sudo supervisorctl reload`

--- a/devops/tracker-nginx.conf
+++ b/devops/tracker-nginx.conf
@@ -1,0 +1,25 @@
+server {
+	server_name traintracker.transitmatters.org;
+	location / {
+		proxy_pass http://127.0.0.1:5001;
+	}
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/traintracker.transitmatters.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/traintracker.transitmatters.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+server {
+    if ($host = traintracker.transitmatters.org) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+	server_name traintracker.transitmatters.org;
+	listen 80;
+    return 404; # managed by Certbot
+
+
+}

--- a/devops/tracker-supervisor.conf
+++ b/devops/tracker-supervisor.conf
@@ -1,0 +1,9 @@
+[program:new-train-tracker]
+directory=/home/ubuntu/new-train-tracker/server
+command=/home/ubuntu/.local/bin/pipenv run gunicorn -b localhost:5001 -w 1 application:application
+user=ubuntu
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+


### PR DESCRIPTION
Adding deployment server config files to source control. We'll have to be careful to also update these if we ever make changes on the server.

The nginx conf gets cp'd into /etc/nginx/sites-enabled/
The supervisor conf gets cp'd into /etc/supervisor/conf.d/

Note that the supervisor run command only starts the gunicorn server, so if changes are made, npm build will have to be run manually before restarting supervisor with `sudo supervisorctl reload`.

Am I missing some details? Should some of this info go in README also?