### PR TITLE
Add author and description meta tags

### DIFF
--- a/static/template.html
+++ b/static/template.html
@@ -9,6 +9,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="author" content="TransitMatters">
+  <meta name="description" content="Live tracking of MBTA's new Orange, Green, and Red Line trains brought to you by the TransitMatters Labs team.">
   <title>New Train Tracker</title>
 </head>
 


### PR DESCRIPTION
Some additional html meta tags should help this search result look better:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/193453/97656542-16ef2d00-1a3e-11eb-9d5f-8822a84aa772.png">
