### PR TITLE
Use tweaked version of json-api-doc

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,9 +9,9 @@ black = "*"
 
 [packages]
 flask = "*"
-json-api-doc = "*"
 aiohttp = "*"
 psycopg2-binary = "*"
+json-api-doc = {editable = true, git = "https://github.com/austinjpaul/json-api-doc.git"}
 
 [requires]
 python_version = "3.8"


### PR DESCRIPTION
This probably isn't how we want to address the issue long term. It might not be how we want to address the issue short-term either, but it should serve as a stop-gap measure to keep our site working.

Due to an issue in the parsing algorithm of json-api-doc, the structure of certain API requests from the T (likely just those when a route_pattern's representative trip is running) is causing the json-api-doc library to infinitely recurse. I've opened a PR for this fix here, https://github.com/noplay/json-api-doc/pull/21, but have to wait and see if it gets taken up.

Q: Should I commit Pipfile.lock also?