### PR TITLE
update: Start tracking new SL vehicles in history db

### DIFF
--- a/server/fleet.py
+++ b/server/fleet.py
@@ -1,38 +1,33 @@
+from server.routes import GREEN_ROUTE_IDS, SILVER_ROUTE_IDS
+
 red_is_new = lambda x: int(x) >= 1900 and int(x) <= 2151
 green_is_new = lambda x: int(x) >= 3900 and int(x) <= 3924
 orange_is_new = lambda x: int(x) >= 1400 and int(x) <= 1551
+silver_is_new = lambda x: int(x) >= 1294 and int(x) <= 1
+
+
+def get_is_new_dict(route_ids, test_fn):
+    return {route_id: test_fn for route_id in route_ids}
+
 
 train_is_new_func = {
     "Red-A": red_is_new,
     "Red-B": red_is_new,
     "Orange": orange_is_new,
-    "Green-B": green_is_new,
-    "Green-C": green_is_new,
-    "Green-D": green_is_new,
-    "Green-E": green_is_new,
-}
-
-green_new_test = lambda x: True
-train_is_new_func_test = {
-    "Red-A": lambda x: True,
-    "Red-B": lambda x: True,
-    "Orange": lambda x: True,
-    "Green-B": green_new_test,
-    "Green-C": green_new_test,
-    "Green-D": green_new_test,
-    "Green-E": green_new_test,
+    **get_is_new_dict(GREEN_ROUTE_IDS, green_is_new),
+    **get_is_new_dict(SILVER_ROUTE_IDS, silver_is_new),
 }
 
 
 def car_is_new(route_name, car, test_mode=False):
     if test_mode:
-        return train_is_new_func_test[route_name](car)
+        return True
     else:
         return train_is_new_func[route_name](car)
 
 
 def car_array_is_new(route_name, arr, test_mode=False):
     if test_mode:
-        return any(map(train_is_new_func_test[route_name], arr))
+        return True
     else:
         return any(map(train_is_new_func[route_name], arr))

--- a/server/history/update_history_db.py
+++ b/server/history/update_history_db.py
@@ -7,12 +7,12 @@ import psycopg2.extras
 import server.mbta_api as mbta_api
 from server.fleet import car_is_new
 from server.routes import get_line_for_route
-from server.routes import DEFAULT_ROUTE_IDS
+from server.routes import DEFAULT_ROUTE_IDS, SILVER_ROUTE_IDS
 from server.history.util import get_history_db_connection, HISTORY_TABLE_NAME
 
 
 async def update_history(test_mode=False):
-    routes = DEFAULT_ROUTE_IDS
+    routes = DEFAULT_ROUTE_IDS + SILVER_ROUTE_IDS
     now = datetime.datetime.now(pytz.utc)
     eastern = pytz.timezone('US/Eastern')
     postgres_conn = get_history_db_connection()

--- a/server/routes.py
+++ b/server/routes.py
@@ -14,9 +14,7 @@ def derive_custom_route_name(vehicle):
     return default_route_id
 
 
-def derive_custom_direction_destinations(
-    route, normalized_route_name, custom_route_name
-):
+def derive_custom_direction_destinations(route, normalized_route_name, custom_route_name):
     if normalized_route_name == "Red":
         if custom_route_name == "Red-A":
             return ["Ashmont", "Alewife"]
@@ -50,12 +48,25 @@ def get_line_for_route(route):
     return route.split("-")[0]
 
 
-DEFAULT_ROUTE_IDS = [
+GREEN_ROUTE_IDS = [
     "Green-B",
     "Green-C",
     "Green-D",
     "Green-E",
+]
+
+DEFAULT_ROUTE_IDS = [
     "Orange",
     "Red-A",
     "Red-B",
+    *GREEN_ROUTE_IDS,
+]
+
+SILVER_ROUTE_IDS = [
+    "741",
+    "742",
+    "743",
+    "751",
+    "749",
+    "746",
 ]


### PR DESCRIPTION
This PR allows us to start tracking new Silver Line vehicles in the history database, either for internal data-crunching or maybe eventually in a new tab of the Train Tracker UI.

_Test plan:_
- I ran `pipenv run python3 -m server.history.update_history_db` and verified that appropriate vehicle rows were added for the Silver Line (it's helpful to set `test_mode=True` here)
- I ran `npm run start` and checked that the tracker itself is working as expected.