### PR TITLE
Add station labels to all Green Line stops on focused route

### DIFF
--- a/server/secrets.py
+++ b/server/secrets.py
@@ -1,6 +1,6 @@
 MBTA_V3_API_KEY = ''
 POSTGRES_DB = 'newtrains'
-POSTGRES_USER = 'ian'  # Update to your Postgres user account if not using ubuntu
+POSTGRES_USER = 'ubuntu'  # Update to your Postgres user account if not using ubuntu
 POSTGRES_PASS = ''  # Add password if required; Uses account auth on linux
 '''
 If you put your api key here, you may want to run

--- a/server/secrets.py
+++ b/server/secrets.py
@@ -1,6 +1,6 @@
 MBTA_V3_API_KEY = ''
 POSTGRES_DB = 'newtrains'
-POSTGRES_USER = 'ubuntu'  # Update to your Postgres user account if not using ubuntu
+POSTGRES_USER = 'ian'  # Update to your Postgres user account if not using ubuntu
 POSTGRES_PASS = ''  # Add password if required; Uses account auth on linux
 '''
 If you put your api key here, you may want to run

--- a/src/components/Line.js
+++ b/src/components/Line.js
@@ -102,7 +102,7 @@ const Line = props => {
         return <>{pathsByRoute}</>;
     };
 
-    const renderStations = () => {
+    const renderStationDots = () => {
         return Object.entries(routes)
             .map(([routeId, { stationPositions }]) => {
                 const isRouteFocused = routeId === focusedRouteId;
@@ -128,13 +128,14 @@ const Line = props => {
                         </text>
                     );
                     return (
-                        <g
-                            key={`${routeId}-${stationId}`}
+                        <circle
+                            cx={0}
+                            cy={0}
+                            r={1}
+                            key={`${routeId}-${stationId}-dot`}
                             transform={`translate(${pos.x}, ${pos.y})`}
-                        >
-                            <circle cx={0} cy={0} r={1} fill={routeColor} />
-                            {label}
-                        </g>
+                            fill={routeColor}
+                        />
                     );
                 });
             })
@@ -154,6 +155,49 @@ const Line = props => {
                 onBlur={() => setFocusedRouteId(null)}
             />
         ));
+    };
+
+    const renderStationLabelsForRouteId = routeId => {
+        const { stationPositions } = routes[routeId];
+        const isRouteFocused = routeId === focusedRouteId;
+        return Object.entries(stationPositions).map(([stationId, pos]) => {
+            const labelPosition = getStationLabelPosition({
+                stationId,
+                routeId,
+                isRouteFocused,
+            });
+            const stationName =
+                stations[stationId] && abbreviateStationName(stations[stationId].name);
+            if (labelPosition && stationName) {
+                return (
+                    <text
+                        fontSize={4}
+                        fill={colors.lines}
+                        textAnchor={labelPosition === 'right' ? 'start' : 'end'}
+                        x={labelPosition === 'right' ? 4 : -4}
+                        y={1.5}
+                        aria-hidden="true"
+                        transform={`translate(${pos.x}, ${pos.y})`}
+                    >
+                        {stationName}
+                    </text>
+                );
+            }
+            return null;
+        });
+    };
+
+    const renderLabelsForUnfocusedStations = () => {
+        return Object.keys(routes)
+            .filter(routeId => routeId !== focusedRouteId)
+            .map(renderStationLabelsForRouteId);
+    };
+
+    const renderLabelsForFocusedStations = () => {
+        if (focusedRouteId) {
+            return renderStationLabelsForRouteId(focusedRouteId);
+        }
+        return null;
     };
 
     const renderTrainsForScreenreader = () => {
@@ -184,8 +228,10 @@ const Line = props => {
                     preserveAspectRatio="xMidYMin"
                 >
                     {renderLine()}
-                    {renderStations()}
+                    {renderLabelsForUnfocusedStations()}
+                    {renderStationDots()}
                     {renderTrains()}
+                    {renderLabelsForFocusedStations()}
                 </svg>
                 {renderTrainsForScreenreader()}
             </PopoverContainerContext.Provider>

--- a/src/components/Line.js
+++ b/src/components/Line.js
@@ -15,11 +15,11 @@ const abbreviateStationName = station =>
         .replace('Hynes Convention Center', 'Hynes')
         .replace('Heath Street', 'Heath');
 
-const sortTrainRoutePairsByDistance = (pairs, allStationPositions) => {
+const sortTrainRoutePairsByDistance = (pairs, stationPositions) => {
     const distanceMap = new Map(
         pairs.map(pair => {
             const { train } = pair;
-            const station = allStationPositions[train.stationId];
+            const station = stationPositions[train.stationId];
             if (station) {
                 const { x, y } = station;
                 const distance = Math.sqrt(x ** 2 + y ** 2);

--- a/src/components/Line.js
+++ b/src/components/Line.js
@@ -44,8 +44,8 @@ const renderEmptyNoticeForLine = line => {
 
 const getRouteColor = (colors, routeId, focusedRouteId) => {
     return routeId === focusedRouteId || focusedRouteId === null
-        ? colors.lines
-        : colors.secondaryLines;
+        ? colors.route
+        : colors.unfocusedRoute;
 };
 
 const Line = props => {
@@ -58,9 +58,9 @@ const Line = props => {
     const [focusedRouteId, setFocusedRouteId] = useState(null);
 
     const colors = {
-        lines: 'white',
-        secondaryLines: '#ffffff55',
-        newTrains: line.color,
+        route: 'white',
+        unfocusedRoute: '#ffffff55',
+        train: line.color,
         background: line.colorSecondary,
     };
 
@@ -105,28 +105,8 @@ const Line = props => {
     const renderStationDots = () => {
         return Object.entries(routes)
             .map(([routeId, { stationPositions }]) => {
-                const isRouteFocused = routeId === focusedRouteId;
                 const routeColor = getRouteColor(colors, routeId, focusedRouteId);
                 return Object.entries(stationPositions).map(([stationId, pos]) => {
-                    const labelPosition = getStationLabelPosition({
-                        stationId,
-                        routeId,
-                        isRouteFocused,
-                    });
-                    const stationName =
-                        stations[stationId] && abbreviateStationName(stations[stationId].name);
-                    const label = labelPosition && stationName && (
-                        <text
-                            fontSize={4}
-                            fill={colors.lines}
-                            textAnchor={labelPosition === 'right' ? 'start' : 'end'}
-                            x={labelPosition === 'right' ? 4 : -4}
-                            y={1.5}
-                            aria-hidden="true"
-                        >
-                            {stationName}
-                        </text>
-                    );
                     return (
                         <circle
                             cx={0}
@@ -172,7 +152,7 @@ const Line = props => {
                 return (
                     <text
                         fontSize={4}
-                        fill={colors.lines}
+                        fill={colors.route}
                         textAnchor={labelPosition === 'right' ? 'start' : 'end'}
                         x={labelPosition === 'right' ? 4 : -4}
                         y={1.5}

--- a/src/components/Train.js
+++ b/src/components/Train.js
@@ -38,7 +38,7 @@ const drawEquilateralTriangle = radius =>
         .trim();
 
 const Train = props => {
-    const { train, route, colors, alwaysLabelTrain, focusOnMount, labelPosition } = props;
+    const { train, route, colors, focusOnMount, labelPosition, onFocus, onBlur } = props;
     const { direction, isNewTrain } = train;
     const { pathInterpolator, stations } = route;
 
@@ -48,14 +48,19 @@ const Train = props => {
 
     const offset = interpolateTrainOffset(train, stations);
     const popoverContainer = useContext(PopoverContainerContext);
-    const isLabelShown = alwaysLabelTrain || isTracked;
 
     const handleFocus = () => {
         setIsTracked(true);
+        if (onFocus) {
+            onFocus();
+        }
     };
 
     const handleBlur = () => {
         setIsTracked(false);
+        if (onBlur) {
+            onBlur();
+        }
     };
 
     useEffect(() => {
@@ -72,7 +77,6 @@ const Train = props => {
         if (element && shouldAutoFocus) {
             setShouldAutoFocus(false);
             element.focus();
-            setIsTracked(true);
         }
     }, [element, shouldAutoFocus]);
 
@@ -117,8 +121,7 @@ const Train = props => {
                                 route={route}
                                 colors={colors}
                                 container={popoverContainer}
-                                isVisible={isLabelShown}
-                                isActive={isTracked}
+                                isVisible={isTracked}
                                 fixedPositionStrategy={labelPosition}
                                 referenceRect={getBoundingRectWithinParent(
                                     element,

--- a/src/components/Train.js
+++ b/src/components/Train.js
@@ -39,7 +39,7 @@ const drawEquilateralTriangle = radius =>
 
 const Train = props => {
     const { train, route, colors, focusOnMount, labelPosition, onFocus, onBlur } = props;
-    const { direction, isNewTrain } = train;
+    const { direction } = train;
     const { pathInterpolator, stations } = route;
 
     const [element, setElement] = useState(null);
@@ -81,14 +81,13 @@ const Train = props => {
     }, [element, shouldAutoFocus]);
 
     const renderTrainMarker = () => {
-        const color = isNewTrain ? colors.newTrains : colors.oldTrains;
         return (
             <g>
                 <circle
                     cx={0}
                     cy={0}
                     r={3.326}
-                    fill={color}
+                    fill={colors.train}
                     stroke={isTracked ? 'white' : undefined}
                 />
                 <polygon points={drawEquilateralTriangle(2)} fill={'white'} />

--- a/src/components/TrainPopover.js
+++ b/src/components/TrainPopover.js
@@ -85,10 +85,8 @@ const TrainPopover = props => {
             style={positionStyle}
             aria-hidden="true"
         >
-            <div className="scale-container" style={{ border: `2px solid ${colors.newTrains}` }}>
-                <div className="train-details">
-                    {renderTrainLabel(train, route, colors.newTrains)}
-                </div>
+            <div className="scale-container" style={{ border: `2px solid ${colors.train}` }}>
+                <div className="train-details">{renderTrainLabel(train, route, colors.train)}</div>
             </div>
         </div>,
         container

--- a/src/lines.js
+++ b/src/lines.js
@@ -84,23 +84,19 @@ export const greenEShape = [
     }),
 ];
 
-// const shouldLabelGLTrain = ({ stationId }) =>
-//     stationId && !labeledGreenLineStations.includes(stationId);
-
 export const greenLine = {
     name: 'Green',
     abbreviation: 'GL',
     color: '#114529',
     colorSecondary: '#159765',
-    shouldLabelTrain: () => false,
-    getStationLabelPosition: stationId => {
-        if (stationId === 'place-hymnl') {
-            return 'left';
-        }
+    getStationLabelPosition: ({ stationId, routeId, isRouteFocused }) => {
         if (labeledGreenLineStations.includes(stationId)) {
-            return 'right';
+            return stationId === 'place-hymnl' ? 'left' : 'right';
         }
-        return false;
+        if (isRouteFocused) {
+            return routeId === 'Green-E' ? 'left' : 'right';
+        }
+        return null;
     },
     routes: {
         'Green-B': {
@@ -124,7 +120,6 @@ export const orangeLine = {
     colorSecondary: '#e66f00',
     color: '#ffaa21',
     getStationLabelPosition: () => 'right',
-    shouldLabelTrain: () => false,
     fixedTrainLabelPosition: 'right',
     routes: {
         Orange: {
@@ -175,7 +170,6 @@ export const redLine = {
     color: '#E37C7C',
     colorSecondary: '#D13434',
     getStationLabelPosition: () => 'right',
-    shouldLabelTrain: () => false,
     routes: {
         'Red-A': {
             derivedFromRouteId: 'Red',

--- a/src/main.css
+++ b/src/main.css
@@ -213,9 +213,14 @@ a {
 
 .train {
     cursor: pointer;
+    z-index: -1;
 }
 
 .train.tracked {
+    pointer-events: none;
+}
+
+.station-label {
     pointer-events: none;
 }
 

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -104,6 +104,7 @@ export const prerenderLine = (line, stationsByRoute, routesInfo) => {
             shape,
             stationIds
         );
+        const routeStationPositions = getStationPositions(stationOffsets, pathInterpolator);
         const route = {
             ...routeInfo,
             id: routeId,
@@ -117,10 +118,12 @@ export const prerenderLine = (line, stationsByRoute, routesInfo) => {
                     offset: stationOffsets[station.id],
                 };
             }),
+            stationPositions: routeStationPositions,
+            pathDirective,
         };
         stationPositions = {
             ...stationPositions,
-            ...getStationPositions(stationOffsets, pathInterpolator),
+            ...routeStationPositions,
         };
         routes[routeId] = route;
         pathBuilder.add(pathDirective);


### PR DESCRIPTION
Resolves #61

Finally! The compromise I came up with is that we'll only show the station names on the route of the focused train, which means that we can show the full station name. It gets a little visually busy, but it it works fairly well.

_Screenshot:_
<img width="372" alt="Screen Shot 2021-12-02 at 8 58 34 PM" src="https://user-images.githubusercontent.com/2208769/144532403-ebab17b3-bfb9-4af7-a1ae-f9a1b887a9a8.png">

_Test plan:_
- Load the tracker with `?testMode=1` and make sure that all line panes render
- Make sure that selecting different Green Line routes works and shows/hides stations as appropriate
- Make sure tabbing between trains still works
