### PR TITLE
Update update_history_db.py to the new mbta_api.py

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "new-train-tracker",
-  "version": "1.0.0",
+  "version": "2.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server/history/update_history_db.py
+++ b/server/history/update_history_db.py
@@ -14,27 +14,22 @@ from server.history.util import get_history_db_connection, HISTORY_TABLE_NAME
 async def update_history(test_mode=False):
     routes = DEFAULT_ROUTE_IDS + SILVER_ROUTE_IDS
     now = datetime.datetime.now(pytz.utc)
-    eastern = pytz.timezone('US/Eastern')
     postgres_conn = get_history_db_connection()
-    json = await mbta_api.vehicle_data_for_routes(routes, test_mode)
+    [vehicles_to_display, _] = await mbta_api.vehicle_data_for_routes(routes, test_mode)
     # Transform all of the current vehicles into easy-to-use form
     vehicles_by_route = {x: [] for x in routes}
     seen_trip_ids = []
-    for vehicle in json:
-        try:
-            route_name = vehicle["route"]
-            if vehicle["tripId"] not in seen_trip_ids:
-                # Dedup trip ids
-                seen_trip_ids.append(vehicle["tripId"])
-                vehicle_set = {
-                    # This can be mixed old/new. Gets filtered before db insertion below
-                    "cars": vehicle["label"].split("-")
-                }
+    for vehicle in vehicles_to_display:
+        route_name = vehicle["route"]
+        if vehicle["tripId"] not in seen_trip_ids:
+            # Dedup trip ids
+            seen_trip_ids.append(vehicle["tripId"])
+            vehicle_set = {
+                # This can be mixed old/new. Gets filtered before db insertion below
+                "cars": vehicle["label"].split("-")
+            }
 
-                vehicles_by_route[route_name].append(vehicle_set)
-        except AttributeError:
-            now_eastern = now.astimezone(eastern)
-            print("[{}] vehicle error: {}".format(now_eastern, vehicle))
+            vehicles_by_route[route_name].append(vehicle_set)
     # Add to PostgreSQL log
     with postgres_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
         # This is a little nasty, but we want to maintain independent db rows for each car in a series (for the green line, where it's mixed new/old)


### PR DESCRIPTION
`mbta_api.vehicle_data_for_routes` updated, and `update_history_db` didn't get the memo :-)

Exception handling removed because the former has its own, so it's fine for `update_history_db` to die if something isn't happy.