### PR TITLE
Conditionally enable postgres connection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Run:
 
 To use an API key, put it in `server/secrets.py` or as an environment variable `MBTA_V3_API_KEY`
 
+To disable the database, set the `POSTGRES_ENABLED` flag to `False` in `server/secrets.py`
+
 On Windows:
 - In `server/secrets.py`, update `POSTGRES_USER` and `POSTGRES_PASS` variables with your credentials.
 

--- a/server/history/recent_sightings.py
+++ b/server/history/recent_sightings.py
@@ -13,6 +13,7 @@ def choose_between_sightings(best, next):
         return next
     return best
 
+
 # Get the last time that a new train was seen on each line
 # If the POSTGRES_ENABLED flag is True, query the database, otherwise generate test data
 def get_recent_sightings_for_lines(test_mode=False):

--- a/server/history/recent_sightings.py
+++ b/server/history/recent_sightings.py
@@ -1,7 +1,9 @@
 from functools import reduce
 import psycopg2.extras
+from datetime import datetime, timedelta
 
 from server.history.util import get_history_db_connection, HISTORY_TABLE_NAME
+from server.secrets import POSTGRES_ENABLED
 
 
 def choose_between_sightings(best, next):
@@ -11,16 +13,26 @@ def choose_between_sightings(best, next):
         return next
     return best
 
-
+# Get the last time that a new train was seen on each line
+# If the POSTGRES_ENABLED flag is True, query the database, otherwise generate test data
 def get_recent_sightings_for_lines(test_mode=False):
+    res = {}
+    lines = ["Orange", "Red", "Green"]
+    if not POSTGRES_ENABLED:
+        res = {}
+        for line in lines:
+            res[line] = {
+                "car": "1234",
+                "time": datetime.utcnow() - timedelta(days=1, hours=1)
+            }
+        return res
     cxn = get_history_db_connection()
     with cxn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
         cursor.execute(
             f"SELECT * FROM {HISTORY_TABLE_NAME} WHERE (%s OR is_new=true)", [test_mode]
         )
         rows = cursor.fetchall()
-    res = {}
-    for line in ("Orange", "Red", "Green"):
+    for line in lines:
         most_recent_sighting = reduce(
             choose_between_sightings,
             filter(lambda row: row["line"] == line, rows),

--- a/server/secrets.py
+++ b/server/secrets.py
@@ -1,4 +1,5 @@
 MBTA_V3_API_KEY = ''
+POSTGRES_ENABLED = False
 POSTGRES_DB = 'newtrains'
 POSTGRES_USER = 'ubuntu'  # Update to your Postgres user account if not using ubuntu
 POSTGRES_PASS = ''  # Add password if required; Uses account auth on linux

--- a/server/secrets.py
+++ b/server/secrets.py
@@ -1,5 +1,5 @@
 MBTA_V3_API_KEY = ''
-POSTGRES_ENABLED = False
+POSTGRES_ENABLED = True
 POSTGRES_DB = 'newtrains'
 POSTGRES_USER = 'ubuntu'  # Update to your Postgres user account if not using ubuntu
 POSTGRES_PASS = ''  # Add password if required; Uses account auth on linux


### PR DESCRIPTION
closes #83
adds a new config flag to optionally disable the database - if it's set to false, the last seen logic will return some dummy data instead of querying the database