### PR TITLE
fix: Also catch `RuntimeError` in `reverse_if_stops_out_of_order`

### DIFF
--- a/server/mbta_api.py
+++ b/server/mbta_api.py
@@ -74,7 +74,7 @@ def reverse_if_stops_out_of_order(stops, first_expected_stop_name, second_expect
         if index_of_first > index_of_second:
             return list(reversed(stops))
         return stops
-    except StopIteration:
+    except (StopIteration, RuntimeError):
         # This shouldn't happen if we specified our stops right
         return stops
 


### PR DESCRIPTION
We get this error message sometimes in `reverse_if_stops_out_of_order`, presumably because of transiently bad data from the API:

```
  File "/home/ubuntu/new-train-tracker/server/mbta_api.py", line 87, in maybe_reverse
    return reverse_if_stops_out_of_order(stops, "Park Street", "Downtown Crossing")
  File "/home/ubuntu/new-train-tracker/server/mbta_api.py", line 70, in reverse_if_stops_out_of_order
    (index_of_first, index_of_second) = (
RuntimeError: generator raised StopIteration
```

[PEP 479](https://peps.python.org/pep-0479/) says that `StopIteration` raised inside a generator becomes a `RuntimeError` after it bubbles out of the originating stack from. I'm...not exactly sure where there is a generator here, but this appears to be the problem.