### PR TITLE
Add Blue Line

### DIFF
--- a/server/fleet.py
+++ b/server/fleet.py
@@ -15,6 +15,7 @@ red_is_new = lambda x: int(x) >= 1900 and int(x) <= 2151
 green_is_new = lambda x: int(x) >= 3900 and int(x) <= 3924
 orange_is_new = lambda x: int(x) >= 1400 and int(x) <= 1551
 silver_is_new = lambda x: int(x) >= 1294 and int(x) <= 1299
+blue_is_new = False
 
 
 def get_is_new_dict(route_ids, test_fn):
@@ -25,6 +26,7 @@ vehicle_is_new_func = {
     "Red-A": red_is_new,
     "Red-B": red_is_new,
     "Orange": orange_is_new,
+    "Blue": blue_is_new,
     **get_is_new_dict(GREEN_ROUTE_IDS, green_is_new),
     **get_is_new_dict(SILVER_ROUTE_IDS, silver_is_new),
 }

--- a/server/fleet.py
+++ b/server/fleet.py
@@ -15,7 +15,7 @@ red_is_new = lambda x: int(x) >= 1900 and int(x) <= 2151
 green_is_new = lambda x: int(x) >= 3900 and int(x) <= 3924
 orange_is_new = lambda x: int(x) >= 1400 and int(x) <= 1551
 silver_is_new = lambda x: int(x) >= 1294 and int(x) <= 1299
-blue_is_new = False
+blue_is_new = lambda _: False
 
 
 def get_is_new_dict(route_ids, test_fn):

--- a/server/history/recent_sightings.py
+++ b/server/history/recent_sightings.py
@@ -4,7 +4,7 @@ import psycopg2.extras
 from server.history.util import get_history_db_connection, HISTORY_TABLE_NAME
 from server.secrets import POSTGRES_ENABLED
 
-LINES = ["Orange", "Red", "Green"]
+LINES = ["Orange", "Red", "Green", "Blue"]
 
 
 def choose_between_sightings(best, next):

--- a/server/mbta_api.py
+++ b/server/mbta_api.py
@@ -87,6 +87,8 @@ def maybe_reverse(stops, route):
         return reverse_if_stops_out_of_order(stops, "Park Street", "Downtown Crossing")
     if route == "Orange":
         return reverse_if_stops_out_of_order(stops, "Oak Grove", "Wellington")
+    if route == "Blue":
+        return reverse_if_stops_out_of_order(stops, "Bowdoin", "Wonderland")
     return stops
 
 
@@ -151,6 +153,7 @@ def calc_stats(vehicle_array):
     totalGreen = filter_route("Green", vehicle_array)
     totalOrange = filter_route("Orange", vehicle_array)
     totalRed = filter_route("Red", vehicle_array)
+    totalBlue = filter_route("Blue", vehicle_array)
 
     # intialize dictionary of stats
     vehicle_stats = {
@@ -165,6 +168,10 @@ def calc_stats(vehicle_array):
         "Red": {
             "totalActive": len(totalRed),
             "totalNew": len(filter_new(totalRed))
+        },
+        "Blue": {
+            "totalActive": len(totalBlue),
+            "totalNew": len(filter_new(totalBlue))
         }
     }
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -11,6 +11,7 @@ GREEN_ROUTE_IDS = [
 
 DEFAULT_ROUTE_IDS = [
     "Orange",
+    "Blue",
     "Red-A",
     "Red-B",
     *GREEN_ROUTE_IDS,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect } from 'react';
 import Favicon from 'react-favicon';
 import { useTabState } from 'reakit';
 
-import { greenLine, orangeLine, redLine } from '../lines';
+import { greenLine, orangeLine, redLine, blueLine } from '../lines';
 import { useMbtaApi } from '../useMbtaApi';
 import { getInitialDataByKey } from '../initialData';
 
@@ -18,6 +18,7 @@ const lineByTabId = {
     'tab-Green': greenLine,
     'tab-Orange': orangeLine,
     'tab-Red': redLine,
+    'tab-Blue': blueLine,
 };
 
 const App = () => {

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -235,9 +235,9 @@ export const blueLine = {
             shape: [
                 start(0, 0, 90),
                 stationRange({
-                    end: BLStations.Bowdoin,
-                    start: BLStations.Wonderland,
-                    commands: [line(250)],
+                    end: BLStations.Wonderland,
+                    start: BLStations.Bowdoin,
+                    commands: [line(150)],
                 }),
             ],
         },

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -21,7 +21,7 @@ const GLStations = {
     StMarysStreet: 'place-smary',
     Fenway: 'place-fenwy',
     Prudential: 'place-prmnl',
-} as const
+} as const;
 
 const glSharedStations = [
     GLStations.UnionSquare,
@@ -214,6 +214,32 @@ export const redLine = {
         'Red-B': {
             derivedFromRouteId: 'Red',
             shape: redB,
+        },
+    },
+};
+
+const enum BLStations {
+    Bowdoin = 'place-bomnl',
+    Wonderland = 'place-wondl',
+}
+
+export const blueLine = {
+    name: 'Blue',
+    abbreviation: 'BL',
+    colorSecondary: '#3434D1',
+    color: '#7CA5E3',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        Blue: {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    end: BLStations.Bowdoin,
+                    start: BLStations.Wonderland,
+                    commands: [line(250)],
+                }),
+            ],
         },
     },
 };


### PR DESCRIPTION
# Description

As new train tracker starts to include more than just new trains, it should also display blue line data. 

This PR is dependent on the changes made by @devinmatte in #104.

# Demo 
https://user-images.githubusercontent.com/35850765/183221034-fba15636-e34d-4619-8eb7-073ea89644de.mov

