### PR TITLE
Change badge display source workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: lint
 
-on: pull_request
+on:  
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   frontend:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # New Train Tracker
-![lint](https://github.com/transitmatters/new-train-tracker/workflows/lint/badge.svg)
-![deploy](https://github.com/transitmatters/new-train-tracker/workflows/deploy/badge.svg)
+![lint](https://github.com/transitmatters/new-train-tracker/workflows/lint/badge.svg?branch=master)
+![deploy](https://github.com/transitmatters/new-train-tracker/workflows/deploy/badge.svg?branch=master)
 
 Developed by [TransitMatters](https://transitmatters.org/)
 


### PR DESCRIPTION
Right now, the README badges display the status of the most recent workflow run, including those on PRs. This means that it sometimes appears that things are failing when they actually aren't. This PR adds a lint run to each push to `master` and updates the badges to only show workflows run against `master` so the badges reflect only the `master` branch.