### PR TITLE
Fix Red Line braintree branch 20221029

### DIFF
--- a/server/mbta_api.py
+++ b/server/mbta_api.py
@@ -105,6 +105,10 @@ async def vehicle_data_for_routes(route_ids):
 
     # iterate over all vehicles fetched from V3 API
     for vehicle in vehicles:
+        # Skip vehicles that don't have a stop
+        if vehicle["stop"] is None:
+            continue
+
         try:
             # derive Red Line vehicle branch if needed
             custom_route = derive_custom_route_name(vehicle)

--- a/server/routes.py
+++ b/server/routes.py
@@ -25,6 +25,19 @@ SILVER_ROUTE_IDS = [
     "746",
 ]
 
+RED_A_STOP_IDS = [
+    "70085",
+    "70086",
+    "70087",
+    "70088",
+    "70089",
+    "70090",
+    "70091",
+    "70092",
+    "70093",
+    "70094",
+]
+
 
 # "normalizes" route id by aggregating "Red-A" and "Red-B" ids into "Red"
 def normalize_custom_route_name(route_id):
@@ -43,11 +56,21 @@ def normalize_custom_route_ids(route_ids):
 def derive_custom_route_name(vehicle):
     default_route_id = vehicle["route"]["id"]
     if default_route_id == "Red":
+        # First try to figure it out by route pattern
         try:
             route_pattern_name = vehicle["trip"]["route_pattern"]["name"]
             return "Red-A" if "Ashmont" in route_pattern_name else "Red-B"
-        except TypeError:
+        except Exception:
             pass
+        # Second try to figure it out by whether its stop status is on the Ashmont branch
+        try:
+            if vehicle["stop"]["id"] in RED_A_STOP_IDS:
+                return "Red-A"
+            return "Red-B"
+        except Exception:
+            pass
+
+        # If that all fails, RIP
     return default_route_id
 
 


### PR DESCRIPTION
We're not showing trains on the Braintree branch today because we cannot assess their branch assignment with route pattern only. This adds an additional attempt to do it by `stop`.

I also tried to determine it with closest station by physical distance, but that broke JFK/UMass-North Quincy trains because that segment is physically closer to Fields Corner.