### PR TITLE
Added package-lock.json check to CI/CD actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Check if package-lock.json is up to date
+        run: |
+          npx --yes package-lock-utd@1.x.x
       - name: Generate AWS profile
         run: |
           mkdir ~/.aws

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
             node-version: 16
+      - name: Check if package-lock.json is up to date
+        run: |
+          npx --yes package-lock-utd@1.x.x
       - name: Lint frontend code with ESLint
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
@@ -39,6 +42,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
             node-version: 16
+      - name: Check if package-lock.json is up to date
+        run: |
+          npx --yes package-lock-utd@1.x.x
       - name: Lint backend code with Flake8
         run: |
           curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
While doing some RRE work I came across this npm package: https://www.npmjs.com/package/package-lock-utd

tl;dr it provides a one-liner command that verifies that package-lock.json is up-to-date

Proposing here to add it to all our CI/CD actions as an extra layer of assurance and to help us keep our dependencies straight