### PR TITLE
Fix Header Resizing on small screens

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -50,7 +50,7 @@ a {
 }
 
 .header {
-    padding: 2vh 0;
+    padding: 1rem 0;
     z-index: 1;
     position: sticky;
     top: 0;
@@ -216,10 +216,6 @@ a {
 }
 
 @media screen and (max-height: 600px) {
-    :root {
-        font-size: 2vh;
-        --top-content-height: 20vh;
-    }
 }
 
 .line-pane svg {


### PR DESCRIPTION
## Motivation

See Issue #86 
<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes

- Removes CSS styles that set header relative to the view height on shorter screens.
- Replaced 2vh padding around header with constant 1rem

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

Recreate behavior shown on issue #86 

<!-- How can the reviewer confirm these changes do what you say they do? -->

