### PR TITLE
Bump Python to 3.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['18']
-        python-version: ['3.11']
+        python-version: ['3.12']
     env:
       TM_NTT_CERT_ARN: ${{ secrets.TM_NTT_CERT_ARN }}
       TM_LABS_WILDCARD_CERT_ARN: ${{ secrets.TM_LABS_WILDCARD_CERT_ARN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['18']
-        python-version: ['3.11']
+        python-version: ['3.12']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['18']
-        python-version: ['3.11']
+        python-version: ['3.12']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ inventory
 last_seen.json
 traintracker-dev.nginx.conf
 __pycache__/
+devops/ec2-secrets.py

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Shows new MBTA Orange, Red, and Green Line trains as they come into service.
 ## Install & Run
 Dependencies:
 - `node` `18.x`
-- `python` `3.11`
+- `python` `3.12`
 - [`poetry`](https://python-poetry.org/)
+- Ensure `poetry` is using the correct Python version by running `poetry env use <your python3.12 binary>`
 
 Run:
 - `$ npm install`
@@ -39,8 +40,9 @@ The Flask app is run under gunicorn and controlled by systemd, which will restar
   - `TM_NTT_CERT_ARN` (for production)
   - `TM_LABS_WILDCARD_CERT_ARN` (for beta)
 3. A key named `transitmatters-ntt` needs to be available in your AWS account and copied to `~/.ssh/transitmatters-ntt.pem`.
-4. Run `cd devops && ./deploy.sh` (add `-p` for production) to deploy.
-5. You're all set! Visit:
+4. You will also need to create an `ec2-secrets.py` file in the `devops/` directory.
+5. Run `cd devops && ./deploy.sh` (add `-p` for production) to deploy.
+6. You're all set! Visit:
 - https://ntt-beta.labs.transitmatters.org for beta
 - https://traintracker.transitmatters.org for production
 

--- a/devops/deploy-playbook.yml
+++ b/devops/deploy-playbook.yml
@@ -32,11 +32,11 @@
         repo: ppa:deadsnakes/ppa
         update_cache: yes
 
-    - name: install python3.11
+    - name: install python3.12
       become: yes
       become_user: root
       apt:
-        name: python3.11
+        name: python3.12
         state: latest
 
     - name: install poetry
@@ -82,8 +82,8 @@
         state: restarted
         daemon_reload: yes
 
-    - name: ensure using python 3.11 poetry environment
-      shell: /home/ubuntu/.local/bin/poetry env use 3.11
+    - name: ensure using python 3.12 poetry environment
+      shell: /home/ubuntu/.local/bin/poetry env use 3.12
       args:
         chdir: /home/ubuntu/new-train-tracker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "new-train-tracker",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "new-train-tracker",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "new-train-tracker",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "description": "New Train Tracker by TransitMattters",
     "main": "index.tsx",
     "scripts": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,13 +220,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.42"
+version = "1.34.44"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.42-py3-none-any.whl", hash = "sha256:93755c3ede4bd9f6180b3118f6b607acca8b633fd2668226794a543ce79a2434"},
-    {file = "botocore-1.34.42.tar.gz", hash = "sha256:cf4fad50d09686f03e44418fcae9dd24369658daa556357cedc0790cfcd6fdac"},
+    {file = "botocore-1.34.44-py3-none-any.whl", hash = "sha256:8d9837fb33256e70b9c8955a32d3e60fa70a0b72849a909737cf105fcc3b5deb"},
+    {file = "botocore-1.34.44.tar.gz", hash = "sha256:b0f40c54477e8e0a5c43377a927b8959a86bb8824aaef2d28db7c9c367cdefaa"},
 ]
 
 [package.dependencies]
@@ -1122,5 +1122,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "~3.11"
-content-hash = "96141151a5e956fd0d5b996076161cae9d519ea77e0ea6afdac040ad895e2d0a"
+python-versions = "~3.12"
+content-hash = "4426b157f74dc98e37175e90f5c146e8de54386c0fbea987ab4cc3c24645cc9f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "new-train-tracker"
-version = "2.3.2"
+version = "2.3.3"
 description = "New Train Tracker by TransitMattters"
 authors = ["TransitMatters Labs Team"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "~3.11"
+python = "~3.12"
 flask = "3.0.0"
 aiohttp = "3.9.1"
 boto3 = "1.34.2"

--- a/server/mbta_api.py
+++ b/server/mbta_api.py
@@ -42,7 +42,7 @@ async def getV3(command, params={}, session=None):
             eastern = pytz.timezone("US/Eastern")
             now_eastern = datetime.datetime.now(eastern)
             if response.status >= 400:
-                print(f"[{now_eastern}] API returned {response.status} for {url} -- it says {response_json}")
+                raise Exception(f"[{now_eastern}] API returned {response.status} for {url} -- it says {response_json}")
             try:
                 return json_api_doc.parse(response_json)
             except Exception as e:


### PR DESCRIPTION
## Motivation
Fixes #150 and kills time on Amtrak

## Changes
- Bumps Python version from 3.11 to 3.12
- Change log line to proper Exception to help debug V3 API issues
- Add `devops/ec2-secrets.py` to `.gitignore`
- README updates (@mathcolo this is what I was pinging you about lol)

## Testing Instructions
Currently deployed on beta: https://ntt-beta.labs.transitmatters.org
