### PR TITLE
feat(train-popover): add last updated date and predicted departure

### DIFF
--- a/server/fleet.py
+++ b/server/fleet.py
@@ -8,7 +8,6 @@ fleet.py provides functions used to determine whether vehicles are "new" or not
 
 """
 
-
 from server.routes import GREEN_ROUTE_IDS, SILVER_ROUTE_IDS
 
 red_is_new = lambda x: int(x) >= 1900 and int(x) <= 2151

--- a/server/mbta_api.py
+++ b/server/mbta_api.py
@@ -3,7 +3,6 @@ mbta_api.py provides functions dealing with interactions with the MBTA V3 API
 
 """
 
-
 from urllib.parse import urlencode
 import datetime
 import pytz
@@ -86,13 +85,9 @@ def maybe_reverse(stops, route):
         return reverse_if_stops_out_of_order(stops, "Wonderland", "Bowdoin")
     return stops
 
+
 async def departure_prediction_for_vehicle(vehicle_id, stop_id):
-    predictions = await getV3(
-            "predictions",
-            {
-                "filter[stop]": stop_id
-            }
-    )
+    predictions = await getV3("predictions", {"filter[stop]": stop_id})
 
     for prediction in predictions:
         if prediction["vehicle"]["id"] == vehicle_id:
@@ -144,7 +139,7 @@ async def vehicle_data_for_routes(route_ids):
                     "tripId": vehicle["trip"]["id"],
                     "isNewTrain": is_new,
                     "updatedAt": vehicle["updated_at"],
-                    "departurePrediction": departure_prediction
+                    "departurePrediction": departure_prediction,
                 }
             )
 

--- a/server/mbta_api.py
+++ b/server/mbta_api.py
@@ -86,6 +86,20 @@ def maybe_reverse(stops, route):
         return reverse_if_stops_out_of_order(stops, "Wonderland", "Bowdoin")
     return stops
 
+async def departure_prediction_for_vehicle(vehicle_id, stop_id):
+    predictions = await getV3(
+            "predictions",
+            {
+                "filter[stop]": stop_id
+            }
+    )
+
+    for prediction in predictions:
+        if prediction["vehicle"]["id"] == vehicle_id:
+            return prediction["departure_time"]
+
+    return None
+
 
 # takes a list of route ids
 # uses getV3 to request real-time vehicle data for a given route id
@@ -116,6 +130,8 @@ async def vehicle_data_for_routes(route_ids):
             # determine if vehicle is new
             is_new = fleet.vehicle_array_is_new(custom_route, vehicle["label"].split("-"))
 
+            departure_prediction = await departure_prediction_for_vehicle(vehicle["id"], vehicle["stop"]["id"])
+
             vehicles_to_display.append(
                 {
                     "label": vehicle["label"],
@@ -127,6 +143,8 @@ async def vehicle_data_for_routes(route_ids):
                     "stationId": vehicle["stop"]["parent_station"]["id"],
                     "tripId": vehicle["trip"]["id"],
                     "isNewTrain": is_new,
+                    "updatedAt": vehicle["updated_at"],
+                    "departurePrediction": departure_prediction
                 }
             )
 

--- a/server/secrets.py
+++ b/server/secrets.py
@@ -1,4 +1,4 @@
-MBTA_V3_API_KEY = ''
+MBTA_V3_API_KEY = ""
 # False by default, because debug Flask spawns two processes, and two last seen updaters will trample each other!
 LAST_SEEN_UPDATE = False
 """

--- a/src/labels.tsx
+++ b/src/labels.tsx
@@ -21,7 +21,7 @@ const getReadableStatusLabel = (status) => {
 
 const getDepartureTimePrediction = (prediction: Date) => {
     if (prediction) {
-        return `Departure at ${prediction.toLocaleTimeString()}`;
+        return `Next departure ${prediction.toLocaleTimeString()}`;
     }
 
     return '';
@@ -29,7 +29,7 @@ const getDepartureTimePrediction = (prediction: Date) => {
 
 const getLastUpdatedAt = (updatedAt: Date) => {
     if (updatedAt) {
-        return `Last updated ${updatedAt.toLocaleTimeString()}`;
+        return `Postion updated ${updatedAt.toLocaleTimeString()}`;
     }
     return '';
 };

--- a/src/labels.tsx
+++ b/src/labels.tsx
@@ -19,6 +19,21 @@ const getReadableStatusLabel = (status) => {
     return '';
 };
 
+const getDepartureTimePrediction = (prediction: Date) => {
+    if (prediction) {
+        return `Departure at ${prediction.toLocaleTimeString()}`;
+    }
+
+    return '';
+};
+
+const getLastUpdatedAt = (updatedAt: Date) => {
+    if (updatedAt) {
+        return `Last updated ${updatedAt.toLocaleTimeString()}`;
+    }
+    return '';
+};
+
 const getStationNameAndStatusForTrain = (train: Train, route: Route) => {
     const { stations } = route;
     const nearStation = stations?.find((st) => st.id === train.stationId);
@@ -35,6 +50,7 @@ const renderStationLabel = (train: Train, route: Route) => {
     if (!stationName) {
         return null;
     }
+
     return (
         <div className="station">
             {statusLabel}&nbsp;
@@ -61,12 +77,25 @@ const renderLeadCarLabel = (train: Train, backgroundColor) => {
     );
 };
 
+const renderDetailsLabel = (train: Train) => {
+    const departurePrediction = getDepartureTimePrediction(new Date(train.departurePrediction));
+    const lastUpdated = getLastUpdatedAt(new Date(train.updatedAt));
+
+    return (
+        <div className="details">
+            <p>{departurePrediction}</p>
+            <p>{lastUpdated}</p>
+        </div>
+    );
+};
+
 export const renderTrainLabel = (train: Train, route: Route, accentColor) => {
     return (
         <>
             {renderStationLabel(train, route)}
             {renderDestinationLabel(train, route)}
             {renderLeadCarLabel(train, accentColor)}
+            {renderDetailsLabel(train)}
         </>
     );
 };

--- a/src/main.css
+++ b/src/main.css
@@ -318,6 +318,10 @@ a {
     font-size: 3em;
 }
 
+.train-popover .train-details .details {
+    font-size: 2em;
+}
+
 .train-popover .train-details .lead-car {
     font-size: 3em;
     color: white;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface Train {
     route: string;
     stationId: string;
     tripId: string;
+    departurePrediction: string;
+    updatedAt: string;
 }
 
 export interface Station {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->
Closes https://github.com/transitmatters/new-train-tracker/issues/184 
## Changes
![image](https://github.com/transitmatters/new-train-tracker/assets/46619169/1819be48-6587-480f-9315-f1d2bcee75ec)

<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
Run locally and verify that the last updated date and predicted departure appear for trains on each line