### PR TITLE
fix: typo in labels

### DIFF
--- a/devops/cloudformation.json
+++ b/devops/cloudformation.json
@@ -48,6 +48,16 @@
                 ]
             }
         },
+        {
+          "Type" : "AWS::EC2::InstanceConnectEndpoint",
+          "Properties" : {
+              "SecurityGroupIds" : { "Ref": "NTTSecurityGroup" },
+              "SubnetId" : "subnet-6169464f",
+              "Tags" : [
+                  { "Key": "service", "Value": "new-train-tracker" }
+              ]
+            }
+        },
         "NTTSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {

--- a/devops/cloudformation.json
+++ b/devops/cloudformation.json
@@ -48,16 +48,6 @@
                 ]
             }
         },
-        {
-          "Type" : "AWS::EC2::InstanceConnectEndpoint",
-          "Properties" : {
-              "SecurityGroupIds" : { "Ref": "NTTSecurityGroup" },
-              "SubnetId" : "subnet-6169464f",
-              "Tags" : [
-                  { "Key": "service", "Value": "new-train-tracker" }
-              ]
-            }
-        },
         "NTTSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {

--- a/src/labels.tsx
+++ b/src/labels.tsx
@@ -29,7 +29,7 @@ const getDepartureTimePrediction = (prediction: Date) => {
 
 const getLastUpdatedAt = (updatedAt: Date) => {
     if (updatedAt) {
-        return `Postion updated ${updatedAt.toLocaleTimeString()}`;
+        return `Position updated ${updatedAt.toLocaleTimeString()}`;
     }
     return '';
 };


### PR DESCRIPTION
## Motivation
Fix typo, but also add an instance connect resource so that we can use `ec2-instance-connect` in the deploy script instead of ssh'ing via the public IP. 
<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->

## Changes
Fixes the typo and adds an instance connect resource 
<!-- What does this change exactly? Include relevant screenshots, videos, links -->

## Testing Instructions
Check to see if the typo is fixed, run a deploy.
<!-- How can the reviewer confirm these changes do what you say they do? -->
