### PR TITLE
Upgrading poetry dev dependencies section

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1399,6 +1399,7 @@ python-versions = ">=3.7"
 groups = ["main"]
 files = [
     {file = "schedule-1.2.2-py3-none-any.whl", hash = "sha256:5bef4a2a0183abf44046ae0d164cadcac21b1db011bdd8102e4a0c1e91e06a7d"},
+    {file = "schedule-1.2.2.tar.gz", hash = "sha256:15fe9c75fe5fd9b9627f3f19cc0ef1420508f9f9a46f45cd0769ef75ede5f0b7"},
 ]
 
 [package.extras]
@@ -1459,6 +1460,18 @@ groups = ["main"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+]
+
+[[package]]
+name = "tzdata"
+version = "2024.2"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+files = [
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
 
 [[package]]
@@ -1827,4 +1840,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "bf059c89bb12b79cfff5131840d7c6cda876508e5777aff8fe53a0299818dbd4"
+content-hash = "dd6976c7bd81ba07fc1dfb2a55bc2747997dffec069731a680db84e18ae632bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ json-api-doc = "0.15.0"
 pytz = "2024.2"
 schedule = "1.2.2"
 datadog_lambda = "~6.104.0"
+tzdata = "^2024.2"
 
-
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pip = ">=24.0"
 chalice = "1.31.3"
 black = "^24.10.0"


### PR DESCRIPTION
## Motivation

Keeping poetry & dependencies up-to-date for running the train tracker smoothly in the future. Also adding "tzdata" package to allow Windows users to run the app.

## Changes

Changes [tool.poetry.dev-dependencies] to [tool.poetry.group.dev.dependencies] in the pyproject.toml file. 
![poetry_update1](https://github.com/user-attachments/assets/cead781f-7f2e-4f6a-b72c-33b13acfc40b)


Also, for Windows OS, the "tzdata" package is required to get time information for trains in the tracker, so this package is added under [tool.poetry.dev-dependencies].
![poetry_update2](https://github.com/user-attachments/assets/6edee2d4-73f0-4dbd-803d-bac2a0ad95a6)


## Testing Instructions

Confirm these changes by running the train tracker locally! 

Set the current directory to new-train-tracker on your machine with shell command: cd new-train-tracker

Run the program with shell command: npm start

View the tracker in your browser with: [http://localhost:5173/](http://localhost:5173/)




