### PR TITLE
Improve delivery stats for all lines, update to March

### DIFF
--- a/public/static_data.json
+++ b/public/static_data.json
@@ -1,21 +1,23 @@
 {
     "Orange": {
-        "totalOldActive": 0,
-        "totalOldInactive": 0,
-        "totalNewDelivered": 122,
-        "totalNewUndelivered": 28
+        "totalActive": 130,
+        "totalInactive": 2,
+        "totalNewDelivered": 132,
+        "totalNewUndelivered": 20
     },
     "Red": {
-        "totalOldActive": 220,
+        "totalOldActive": 180,
         "totalOldInactive": 4,
-        "totalNewDelivered": 24,
-        "totalNewUndelivered": 228
+        "totalNewDelivered": 26,
+        "totalNewUndelivered": 226
     },
     "Green": {
-        "totalOldActive": 169,
-        "totalOldInactive": 38,
+        "totalOldActive": 166,
+        "totalOldInactive": 41,
         "totalNewDelivered": 24,
-        "totalNewUndelivered": 0
+        "totalNewUndelivered": 0,
+        "totalType10Delivered": 0,
+        "totalType10Undelivered": 102
     },
     "Blue": {
         "totalActive": 94,
@@ -24,5 +26,5 @@
     "Sources": {
         "fleet_numbers": "http://roster.transithistory.org/"
     },
-    "Updated": "2024-12-04"
+    "Updated": "2025-03-16"
 }

--- a/src/components/LineStats/LastUpdatedStats.tsx
+++ b/src/components/LineStats/LastUpdatedStats.tsx
@@ -1,0 +1,20 @@
+interface Props {
+    stats: {
+        Updated: string;
+        Sources: {
+            fleet_numbers: string;
+        };
+    };
+}
+
+export const LastUpdatedStats: React.FunctionComponent<Props> = ({ stats }) => {
+    return (
+        <div className={'updated'}>
+            <span style={{ fontWeight: 'bold' }}>Delivery info last updated: </span>
+            <span>{new Date(stats.Updated).toDateString()}</span>
+            {' ('}
+            <a href={stats.Sources.fleet_numbers}>source</a>
+            {')'}
+        </div>
+    );
+};

--- a/src/components/LineStats/LineStats.css
+++ b/src/components/LineStats/LineStats.css
@@ -17,6 +17,7 @@ details summary {
     margin: 0 auto;
     color: white;
     min-width: 300px;
+    text-align: center;
 }
 
 .td {
@@ -34,4 +35,14 @@ td:nth-child(2) {
 
 .updated {
     font-size: smaller;
+}
+
+.train-type-text {
+    text-align: center;
+    font-variant: all-small-caps;
+}
+
+.stat-count {
+    text-align: center;
+    font-weight: bold;
 }

--- a/src/components/LineStats/LineStats.tsx
+++ b/src/components/LineStats/LineStats.tsx
@@ -1,5 +1,7 @@
 import * as stats from '../../../public/static_data.json';
 import { LineName } from '../../types';
+import { LastUpdatedStats } from './LastUpdatedStats';
+import { LineStatsTable } from './LineStatsTable';
 import './LineStats.css';
 
 interface Props {
@@ -7,68 +9,13 @@ interface Props {
 }
 
 export const LineStats: React.FunctionComponent<Props> = ({ line }) => {
-    const lineStats: {
-        totalNewDelivered?: number;
-        totalNewUndelivered?: number;
-        totalOldActive?: number;
-        totalOldInactive?: number;
-        totalActive?: number;
-        totalInactive?: number;
-    } = stats[line];
-
-    if (line === 'Blue') {
-        return (
-            <details className="stats-container">
-                <summary className="stats-title">Stats for {line} line</summary>
-                {lineStats ? (
-                    <table className="stats-table">
-                        <tbody>
-                            <tr>
-                                <td>Train Cars Active:</td>
-                                <td>{lineStats?.totalOldActive}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                ) : null}
-                <div className={'updated'}>
-                    <span style={{ fontWeight: 'bold' }}>Delivery info last updated: </span>
-                    <span>{new Date(stats.Updated).toDateString()}</span> (
-                    <a href={stats.Sources.fleet_numbers}>source</a>)
-                </div>
-            </details>
-        );
-    }
+    const lineStats = stats[line];
 
     return (
         <details className="stats-container">
             <summary className="stats-title">Stats for {line} line</summary>
-            {lineStats ? (
-                <table className="stats-table">
-                    <tbody>
-                        <tr>
-                            <td>New Train Cars Delivered:</td>
-                            <td>{lineStats?.totalNewDelivered}</td>
-                        </tr>
-                        <tr>
-                            <td>New Train Cars Awaiting Delivery:</td>
-                            <td>{lineStats?.totalNewUndelivered}</td>
-                        </tr>
-                        <tr>
-                            <td>Old Train Cars Active:</td>
-                            <td>{lineStats?.totalOldActive}</td>
-                        </tr>
-                        <tr>
-                            <td>Old Train Cars Inactive:</td>
-                            <td>{lineStats?.totalOldInactive}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            ) : null}
-            <div className={'updated'}>
-                <span style={{ fontWeight: 'bold' }}>Delivery info last updated: </span>
-                <span>{new Date(stats.Updated).toDateString()}</span> (
-                <a href={stats.Sources.fleet_numbers}>source</a>)
-            </div>
+            {lineStats && <LineStatsTable line={line} stats={lineStats} />}
+            <LastUpdatedStats stats={stats} />
         </details>
     );
 };

--- a/src/components/LineStats/LineStatsTable.tsx
+++ b/src/components/LineStats/LineStatsTable.tsx
@@ -1,0 +1,107 @@
+import { LineName } from '../../types';
+
+interface LineStatsTableProps {
+    line: LineName;
+    stats: {
+        totalNewDelivered?: number;
+        totalNewUndelivered?: number;
+        totalType10Delivered?: number;
+        totalType10Undelivered?: number;
+        totalOldActive?: number;
+        totalOldInactive?: number;
+        totalActive?: number;
+        totalInactive?: number;
+    };
+}
+
+export const LineStatsTable: React.FC<LineStatsTableProps> = ({ line, stats }) => {
+    // Special case for Green line for Type 10 trains
+    if (line === 'Green') {
+        return (
+            <table className="stats-table">
+                <tbody>
+                    <tr>
+                        <td>
+                            New <span className="train-type-text">Type 9</span> Train Cars
+                            Delivered:
+                        </td>
+                        <td className="stat-count">{stats.totalNewDelivered}</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            New <span className="train-type-text">Type 9</span> Train Cars Awaiting
+                            Delivery:
+                        </td>
+                        <td className="stat-count">{stats.totalNewUndelivered}</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            New <span className="train-type-text">Type 10</span> Train Cars
+                            Delivered:
+                        </td>
+                        <td className="stat-count">{stats.totalType10Delivered}</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            New <span className="train-type-text">Type 10</span> Train Cars Awaiting
+                            Delivery:
+                        </td>
+                        <td className="stat-count">{stats.totalType10Undelivered}</td>
+                    </tr>
+                    <tr>
+                        <td>Old Train Cars Active:</td>
+                        <td className="stat-count">{stats.totalOldActive}</td>
+                    </tr>
+                    <tr>
+                        <td>Old Train Cars Inactive:</td>
+                        <td className="stat-count">{stats.totalOldInactive}</td>
+                    </tr>
+                </tbody>
+            </table>
+        );
+    }
+
+    // For all other lines
+    return (
+        <table className="stats-table">
+            <tbody>
+                {stats.totalActive !== undefined && (
+                    <tr>
+                        <td>Train Cars Active:</td>
+                        <td className="stat-count">{stats.totalActive}</td>
+                    </tr>
+                )}
+                {stats.totalInactive !== undefined && (
+                    <tr>
+                        <td>Train Cars Inactive:</td>
+                        <td className="stat-count">{stats.totalInactive}</td>
+                    </tr>
+                )}
+                {stats.totalNewDelivered !== undefined && (
+                    <tr>
+                        <td>New Train Cars Delivered:</td>
+                        <td className="stat-count">{stats.totalNewDelivered}</td>
+                    </tr>
+                )}
+                {stats.totalNewUndelivered !== undefined && (
+                    <tr>
+                        <td>New Train Cars Awaiting Delivery:</td>
+                        <td className="stat-count">{stats.totalNewUndelivered}</td>
+                    </tr>
+                )}
+                {stats.totalOldActive !== undefined && (
+                    <tr>
+                        <td>Old Train Cars Active:</td>
+                        <td className="stat-count">{stats.totalOldActive}</td>
+                    </tr>
+                )}
+                {stats.totalOldInactive !== undefined && (
+                    <tr>
+                        <td>Old Train Cars Inactive:</td>
+                        <td className="stat-count">{stats.totalOldInactive}</td>
+                    </tr>
+                )}
+            </tbody>
+        </table>
+    );
+};


### PR DESCRIPTION
## Motivation

Update Delivery stats to make more sense

## Changes

- Ensure we show Type 9 and Type 10 delivery stats
- Fix Orange line display
- Cleanup code to be easier to maintain

<img width="483" alt="Screenshot 2025-03-29 at 3 17 59 PM" src="https://github.com/user-attachments/assets/be4214e4-d31b-4171-bb6b-76cb98716045" />


## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
