### PR TITLE
Add Speed in Miles Per Hour (#233)

### DIFF
--- a/server/chalicelib/mbta_api.py
+++ b/server/chalicelib/mbta_api.py
@@ -144,6 +144,7 @@ async def vehicle_data_for_routes(route_ids):
                     "carriages": vehicle["carriages"],
                     "updatedAt": vehicle["updated_at"],
                     "isPrideCar": is_pride_car,
+                    "speed": vehicle["speed"],
                 }
             )
 

--- a/src/labels.tsx
+++ b/src/labels.tsx
@@ -37,6 +37,15 @@ const getLastUpdatedAt = (updatedAt: Date) => {
     return '';
 };
 
+const getVehicleSpeed = (vehicleSpeed: number | null) => {
+    if (vehicleSpeed) {
+        // Convert m/s to mph
+        const mph = vehicleSpeed * 2.23694;
+        return `Speed: ${Math.round((mph + Number.EPSILON) * 100) / 100} mph`;
+    }
+    return '';
+};
+
 const getStationNameAndStatusForTrain = (train: Train, route: Route) => {
     const { stations } = route;
     const nearStation = stations?.find((st) => st.id === train.stationId);
@@ -85,11 +94,13 @@ const renderDetailsLabel = (train: Train, prediction: Prediction | null) => {
         prediction ? new Date(prediction.departure_time) : null
     );
     const lastUpdated = getLastUpdatedAt(new Date(train.updatedAt));
+    const speed = getVehicleSpeed(train.speed);
 
     return (
         <div className="details">
             <p>{departurePrediction}</p>
             <p>{lastUpdated}</p>
+            <p>{speed}</p>
         </div>
     );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface Train {
     tripId: string;
     updatedAt: string;
     isPrideCar: boolean;
+    speed: number | null;
 }
 
 export interface Station {


### PR DESCRIPTION
## Motivation

A user requested that we show speed of the trains when available. 

## Changes

<img width="154" height="245" alt="image" src="https://github.com/user-attachments/assets/dccd45a4-497a-4c4c-b501-06af27b4e411" />

Calculated the rounding to 2 decimal places using the solution found on this [Stack Overflow](https://stackoverflow.com/questions/11832914/how-to-round-to-at-most-2-decimal-places-if-necessary).

## Testing Instructions

Set up a dev instance and click on trains until one has speed value available. It seems to be mostly available on Green Line trains. 