### PR TITLE
Added support for Mattapan Line (#130)

### DIFF
--- a/server/chalicelib/fleet.py
+++ b/server/chalicelib/fleet.py
@@ -15,6 +15,7 @@ green_is_new = lambda x: int(x) >= 3900 and int(x) <= 3924
 orange_is_new = lambda x: int(x) >= 1400 and int(x) <= 1551
 silver_is_new = lambda x: int(x) >= 1294 and int(x) <= 1299
 blue_is_new = lambda _: False
+mattapan_is_new = lambda _: False
 
 
 def get_route_test_function_dict(route_ids, test_fn):
@@ -28,6 +29,7 @@ vehicle_is_new_func = {
     **get_route_test_function_dict(GREEN_ROUTE_IDS, green_is_new),
     **get_route_test_function_dict(SILVER_ROUTE_IDS, silver_is_new),
     "Blue": blue_is_new,
+    "Mattapan": mattapan_is_new,
 }
 
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect } from 'react';
 import Favicon from 'react-favicon';
 
-import { greenLine, orangeLine, redLine, blueLine } from '../lines';
+import { greenLine, orangeLine, redLine, blueLine, mattapanLine } from '../lines';
 import { useMbtaApi } from '../hooks/useMbtaApi';
 
 import { Line } from './Line';
@@ -24,6 +24,7 @@ const lineByTabId: Record<LineName, TLine> = {
     Orange: orangeLine,
     Red: redLine,
     Blue: blueLine,
+    Mattapan: mattapanLine,
 };
 
 export const App: React.FC = () => {

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -275,3 +275,29 @@ export const blueLine: Line = {
         },
     },
 };
+
+const enum MattapanStations {
+    Ashmont = 'place-asmnl',
+    Mattapan = 'place-matt',
+}
+
+export const mattapanLine: Line = {
+    name: 'Mattapan',
+    abbreviation: 'MT',
+    color: '#E37C7C',
+    colorSecondary: '#D13434',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        Mattapan: {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: MattapanStations.Ashmont,
+                    end: MattapanStations.Mattapan,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type LineName = 'Green' | 'Red' | 'Orange' | 'Blue';
+export type LineName = 'Green' | 'Red' | 'Orange' | 'Blue' | 'Mattapan';
 
 export interface Line {
     name: LineName;


### PR DESCRIPTION
## Motivation

A user requested that we add support for the Mattapan Trolley per #130 to help with tracking the PCC cars. 

## Changes

Added new tab entitled "MT" for Mattapan Trolley to track Mattapan Trolley cars. The "mattapan_is_new" function may need to be updated with the appropriate train car numbers but I'm not sure what number ranges would be of interest. 

## Testing Instructions

Set up a development server, navigate to the Mattapan Trolley tab. Try to break the changes that were made. 