### PR TITLE
Add support for most commuter rail lines

### DIFF
--- a/public/static_data.json
+++ b/public/static_data.json
@@ -27,6 +27,46 @@
         "totalActive": 6,
         "totalInactive": 4
     },
+    "Worcester": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Fairmount": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Fitchburg": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Greenbush": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Haverhill": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Kingston": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Lowell": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Needham": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Providence": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
+    "Franklin": {
+        "totalActive": 109,
+        "totalInactive": 19
+    },
     "Sources": {
         "fleet_numbers": "http://roster.transithistory.org/"
     },

--- a/server/chalicelib/fleet.py
+++ b/server/chalicelib/fleet.py
@@ -16,6 +16,7 @@ orange_is_new = lambda x: int(x) >= 1400 and int(x) <= 1551
 silver_is_new = lambda x: int(x) >= 1294 and int(x) <= 1299
 blue_is_new = lambda _: False
 mattapan_is_new = lambda x: False
+cr_is_new = lambda x: False
 
 
 def get_route_test_function_dict(route_ids, test_fn):
@@ -30,6 +31,18 @@ vehicle_is_new_func = {
     **get_route_test_function_dict(SILVER_ROUTE_IDS, silver_is_new),
     "Blue": blue_is_new,
     "Mattapan": mattapan_is_new,
+    "CR-Worcester": cr_is_new,
+    "CR-Fairmount": cr_is_new,
+    "CR-Fitchburg": cr_is_new,
+    "CR-Greenbush": cr_is_new,
+    "CR-Haverhill": cr_is_new,
+    "CR-Kingston": cr_is_new,
+    "CR-Lowell": cr_is_new,
+    "CR-Needham": cr_is_new,
+    "CR-Franklin-A": cr_is_new,
+    "CR-Franklin-B": cr_is_new,
+    "CR-Providence-A": cr_is_new,
+    "CR-Providence-B": cr_is_new,
 }
 
 

--- a/server/chalicelib/mbta_api.py
+++ b/server/chalicelib/mbta_api.py
@@ -128,6 +128,8 @@ async def vehicle_data_for_routes(route_ids):
 
             is_pride_car = any(carriage.get("label") == "3706" for carriage in vehicle["carriages"])
 
+            is_heritage_car = any([vehicle["label"] == "1030"])
+            
             vehicles_to_display.append(
                 {
                     "vehicleId": vehicle["id"],
@@ -144,6 +146,7 @@ async def vehicle_data_for_routes(route_ids):
                     "carriages": vehicle["carriages"],
                     "updatedAt": vehicle["updated_at"],
                     "isPrideCar": is_pride_car,
+                    "isHeritageCar": is_heritage_car,
                     "speed": vehicle["speed"],
                 }
             )

--- a/server/chalicelib/mbta_api.py
+++ b/server/chalicelib/mbta_api.py
@@ -90,7 +90,7 @@ async def trip_departure_predictions(trip_id: str, stop_id: str):
     try:
         prediction = await getV3("predictions", {"filter[trip]": trip_id, "filter[stop]": stop_id})
 
-        return {'departure_time': prediction[0]['departure_time']}
+        return {"departure_time": prediction[0]["departure_time"]}
     except Exception as e:
         print(f"Error getting predictions for trip: {e}")
         return {"departure_time": "null"}
@@ -129,7 +129,7 @@ async def vehicle_data_for_routes(route_ids):
             is_pride_car = any(carriage.get("label") == "3706" for carriage in vehicle["carriages"])
 
             is_heritage_car = any([vehicle["label"] == "1030"])
-            
+
             vehicles_to_display.append(
                 {
                     "vehicleId": vehicle["id"],

--- a/server/chalicelib/routes.py
+++ b/server/chalicelib/routes.py
@@ -39,11 +39,21 @@ RED_A_STOP_IDS = [
     "70094",
 ]
 
-CR_Franklin_A_STOP_IDS = ["place-FB-0303","place-FB-0275","place-FB-0230","place-FB-0191"]
+CR_Franklin_A_STOP_IDS = ["place-FB-0303", "place-FB-0275", "place-FB-0230", "place-FB-0191"]
 CR_Franklin_B_STOP_IDS = ["place-FS-0049"]
 
-CR_Providence_A_STOP_IDS = ["place-SB-0156","place-SB-0189"]
-CR_Providence_B_STOP_IDS = ["place-NEC-1659","place-NEC-1768", "place-NEC-1851", "place-NEC-1891", "place-NEC-1919", "place-NEC-1969", "place-NEC-2040", "place-NEC-2108"]
+CR_Providence_A_STOP_IDS = ["place-SB-0156", "place-SB-0189"]
+CR_Providence_B_STOP_IDS = [
+    "place-NEC-1659",
+    "place-NEC-1768",
+    "place-NEC-1851",
+    "place-NEC-1891",
+    "place-NEC-1919",
+    "place-NEC-1969",
+    "place-NEC-2040",
+    "place-NEC-2108",
+]
+
 
 # "normalizes" route id by aggregating "Red-A" and "Red-B" ids into "Red"
 def normalize_custom_route_name(route_id):
@@ -53,7 +63,7 @@ def normalize_custom_route_name(route_id):
         return "CR-Franklin"
     if route_id in ("CR-Providence-A", "CR-Providence-B"):
         return "CR-Providence"
-    else: 
+    else:
         return route_id
 
 
@@ -82,7 +92,7 @@ def derive_custom_route_name(vehicle):
             return "Red-B"
         except Exception:
             pass
-        
+
     if default_route_id == "CR-Franklin":
         # First try to figure it out by route pattern
         try:
@@ -97,7 +107,7 @@ def derive_custom_route_name(vehicle):
             return "CR-Franklin-B"
         except Exception:
             pass
-        
+
     if default_route_id == "CR-Providence":
         # First try to figure it out by route pattern
         try:
@@ -129,7 +139,7 @@ def derive_custom_direction_destinations(route, normalized_route_name, custom_ro
             return ["Forge Park/495", "South Station"]
         else:
             return ["Foxboro", "South Station"]
-        
+
     if normalized_route_name == "CR-Providence":
         if custom_route_name == "CR-Providence-A":
             return ["Wickford Junction", "South Station"]

--- a/server/chalicelib/routes.py
+++ b/server/chalicelib/routes.py
@@ -39,10 +39,22 @@ RED_A_STOP_IDS = [
     "70094",
 ]
 
+CR_Franklin_A_STOP_IDS = ["place-FB-0303","place-FB-0275","place-FB-0230","place-FB-0191"]
+CR_Franklin_B_STOP_IDS = ["place-FS-0049"]
+
+CR_Providence_A_STOP_IDS = ["place-SB-0156","place-SB-0189"]
+CR_Providence_B_STOP_IDS = ["place-NEC-1659","place-NEC-1768", "place-NEC-1851", "place-NEC-1891", "place-NEC-1919", "place-NEC-1969", "place-NEC-2040", "place-NEC-2108"]
 
 # "normalizes" route id by aggregating "Red-A" and "Red-B" ids into "Red"
 def normalize_custom_route_name(route_id):
-    return "Red" if route_id in ("Red-A", "Red-B") else route_id
+    if route_id in ("Red-A", "Red-B"):
+        return "Red"
+    if route_id in ("CR-Franklin-A", "CR-Franklin-B"):
+        return "CR-Franklin"
+    if route_id in ("CR-Providence-A", "CR-Providence-B"):
+        return "CR-Providence"
+    else: 
+        return route_id
 
 
 # takes a list of route ids
@@ -70,6 +82,36 @@ def derive_custom_route_name(vehicle):
             return "Red-B"
         except Exception:
             pass
+        
+    if default_route_id == "CR-Franklin":
+        # First try to figure it out by route pattern
+        try:
+            route_pattern_name = vehicle["trip"]["route_pattern"]["name"]
+            return "CR-Franklin-A" if "Forge Park/495" in route_pattern_name else "CR-Franklin-B"
+        except Exception:
+            pass
+        # Second try to figure it out by whether its stop status is on the Ashmont branch
+        try:
+            if vehicle["stop"]["id"] in CR_Franklin_A_STOP_IDS:
+                return "CR-Franklin-A"
+            return "CR-Franklin-B"
+        except Exception:
+            pass
+        
+    if default_route_id == "CR-Providence":
+        # First try to figure it out by route pattern
+        try:
+            route_pattern_name = vehicle["trip"]["route_pattern"]["name"]
+            return "CR-Providence-A" if "Providence" in route_pattern_name else "CR-Providence-B"
+        except Exception:
+            pass
+        # Second try to figure it out by whether its stop status is on the Ashmont branch
+        try:
+            if vehicle["stop"]["id"] in CR_Providence_A_STOP_IDS:
+                return "CR-Providence-A"
+            return "CR-Providence-B"
+        except Exception:
+            pass
 
         # If that all fails, RIP
     return default_route_id
@@ -82,6 +124,17 @@ def derive_custom_direction_destinations(route, normalized_route_name, custom_ro
             return ["Ashmont", "Alewife"]
         else:
             return ["Braintree", "Alewife"]
+    if normalized_route_name == "CR-Franklin":
+        if custom_route_name == "CR-Franklin-A":
+            return ["Forge Park/495", "South Station"]
+        else:
+            return ["Foxboro", "South Station"]
+        
+    if normalized_route_name == "CR-Providence":
+        if custom_route_name == "CR-Providence-A":
+            return ["Wickford Junction", "South Station"]
+        else:
+            return ["Stoughton", "South Station"]
     return route["direction_destinations"]
 
 
@@ -104,6 +157,20 @@ def stop_belongs_to_custom_route(stop_id, custom_route_name, normalized_route_na
             "place-smmnl",
             "place-asmnl",
         )
+    if normalized_route_name != "CR-Franklin":
+        return True
+    if custom_route_name == "CR-Franklin-A":
+        return stop_id not in CR_Franklin_B_STOP_IDS
+    if custom_route_name == "CR-Franklin-B":
+        return stop_id not in CR_Franklin_A_STOP_IDS
+    if normalized_route_name != "CR-Providence":
+        return True
+    if normalized_route_name != "CR-Providence":
+        return True
+    if custom_route_name == "CR-Providence-A":
+        return stop_id not in CR_Providence_B_STOP_IDS
+    if custom_route_name == "CR-Providence-B":
+        return stop_id not in CR_Providence_A_STOP_IDS
     return True
 
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,13 +1,29 @@
 import { useEffect, useLayoutEffect } from 'react';
 import Favicon from 'react-favicon';
 
-import { greenLine, orangeLine, redLine, blueLine, mattapanLine } from '../lines';
+import {
+    greenLine,
+    orangeLine,
+    redLine,
+    blueLine,
+    mattapanLine,
+    crworcesterLine,
+    crfairmountLine,
+    crfitchburgLine,
+    crkingstonLine,
+    crLowellLine,
+    crNeedhamLine,
+    crGreenbushLine,
+    crHaverillLine,
+    crFranklinLine,
+    crProvidenceLine,
+} from '../lines';
 import { useMbtaApi } from '../hooks/useMbtaApi';
 
 import { Line } from './Line';
 import { Header } from './Header';
 import { Footer } from './Footer';
-import { LineTabPicker } from './LineTabPicker';
+import { SeparatedLineTabPicker } from './SeparatedLineTabPicker';
 import { LineStats } from './LineStats/LineStats';
 import { setCssVariable } from './util';
 
@@ -25,6 +41,16 @@ const lineByTabId: Record<LineName, TLine> = {
     Red: redLine,
     Blue: blueLine,
     Mattapan: mattapanLine,
+    Worcester: crworcesterLine,
+    Fairmount: crfairmountLine,
+    Fitchburg: crfitchburgLine,
+    Kingston: crkingstonLine,
+    Lowell: crLowellLine,
+    Needham: crNeedhamLine,
+    Greenbush: crGreenbushLine,
+    Haverhill: crHaverillLine,
+    Franklin: crFranklinLine,
+    Providence: crProvidenceLine,
 };
 
 export const App: React.FC = () => {
@@ -80,7 +106,7 @@ export const App: React.FC = () => {
             <div className={'selectors'}>
                 <CategoryTabPicker tabColor={selectedLine.color} />
                 {api.trainsByRoute && (
-                    <LineTabPicker
+                    <SeparatedLineTabPicker
                         lines={Object.values(lineByTabId)}
                         trainsByRoute={api.trainsByRoute}
                     />

--- a/src/components/CategoryTabPicker.tsx
+++ b/src/components/CategoryTabPicker.tsx
@@ -10,6 +10,7 @@ const trainTypes: TrainCategory[] = [
     { key: 'new_vehicles', label: 'New' },
     { key: 'vehicles', label: 'All' },
     { key: 'pride', label: 'Pride' },
+    { key: 'heritage', label: 'B&M' },
 ];
 
 interface CategoryTabPickerProps {

--- a/src/components/Line.tsx
+++ b/src/components/Line.tsx
@@ -17,6 +17,7 @@ const AGE_WORD_MAP = new Map<VehicleCategory, string>([
     ['old_vehicles', ' old '],
     ['vehicles', ' '],
     ['pride', ' pride '],
+    ['heritage', ' heritage '],
 ]);
 
 interface LineProps {

--- a/src/components/SeparatedLineTabPicker.tsx
+++ b/src/components/SeparatedLineTabPicker.tsx
@@ -1,0 +1,58 @@
+import { Line, Train } from '../types';
+import { LineTabPicker } from './LineTabPicker';
+
+interface SeparatedLineTabPickerProps {
+    lines: Line[];
+    trainsByRoute: { [key: string]: Train[] };
+}
+
+export const SeparatedLineTabPicker: React.FC<SeparatedLineTabPickerProps> = ({
+    lines,
+    trainsByRoute,
+}) => {
+    // Separate subway lines from commuter rail lines
+    const subwayLines = lines.filter(
+        (line) =>
+            !line.name.startsWith('cr') &&
+            ![
+                'Worcester',
+                'Fairmount',
+                'Fitchburg',
+                'Kingston',
+                'Lowell',
+                'Needham',
+                'Greenbush',
+                'Haverhill',
+                'Franklin',
+                'Providence',
+            ].includes(line.name)
+    );
+
+    const commuterRailLines = lines.filter(
+        (line) =>
+            line.name.startsWith('cr') ||
+            [
+                'Worcester',
+                'Fairmount',
+                'Fitchburg',
+                'Kingston',
+                'Lowell',
+                'Needham',
+                'Greenbush',
+                'Haverhill',
+                'Franklin',
+                'Providence',
+            ].includes(line.name)
+    );
+
+    return (
+        <div className="separated-line-tabs">
+            <div className="subway-tabs">
+                <LineTabPicker lines={subwayLines} trainsByRoute={trainsByRoute} />
+            </div>
+            <div className="commuter-rail-tabs">
+                <LineTabPicker lines={commuterRailLines} trainsByRoute={trainsByRoute} />
+            </div>
+        </div>
+    );
+};

--- a/src/hooks/useMbtaApi.ts
+++ b/src/hooks/useMbtaApi.ts
@@ -42,6 +42,10 @@ const filterPride = (trains: Train[]) => {
     return trains.filter((train) => train.isPrideCar);
 };
 
+const filterHeritage = (trains: Train[]) => {
+    return trains.filter((train) => train.isHeritageCar);
+};
+
 const filterTrains = (trains: Train[], vehiclesAge: VehicleCategory) => {
     if (vehiclesAge === 'new_vehicles') {
         return filterNew(trains);
@@ -49,6 +53,8 @@ const filterTrains = (trains: Train[], vehiclesAge: VehicleCategory) => {
         return filterOld(trains);
     } else if (vehiclesAge === 'pride') {
         return filterPride(trains);
+    } else if (vehiclesAge == 'heritage') {
+        return filterHeritage(trains);
     }
     return trains;
 };

--- a/src/lines.ts
+++ b/src/lines.ts
@@ -301,3 +301,334 @@ export const mattapanLine: Line = {
         },
     },
 };
+
+const enum commuterRailStations {
+    SouthStation = 'place-sstat',
+    NorthStation = 'place-north',
+    Haverhill = 'place-WR-0329',
+    Worcester = 'place-WML-0442',
+    Readville = 'place-DB-0095',
+    Wachusett = 'place-FR-3338',
+    Kingston = 'place-KB-0351',
+    Lowell = 'place-NHRML-0254',
+    NeedhamHeights = 'place-NB-0137',
+    Greenbush = 'place-GRB-0276',
+    Franklin = 'place-FB-0275',
+    Foxboro = 'place-FS-0049',
+    WindsorGardens = 'place-FB-0166',
+    ForgePark = 'place-FB-0303',
+    Walpole = 'place-FB-0191',
+    BackBay = 'place-bbsta',
+    Ruggles = 'place-rugg',
+    ForestHills = 'place-forhl',
+    HydePark = 'place-NEC-2203',
+    Endicott = 'place-FB-0109',
+    DedhamCorporateCenter = 'place-FB-0118',
+    Islington = 'place-FB-0125',
+    NorwoodDepot = 'place-FB-0143',
+    NorwoodCentral = 'place-FB-0148',
+    Norfolk = 'place-FB-0230',
+    Stoughton = 'place-SB-0189',
+    CantonCenter = 'place-SB-0156',
+    WickfordJunction = 'place-NEC-1659',
+    TFGreen = 'place-NEC-1768',
+    Providence = 'place-NEC-1851',
+    Pawtucket = 'place-NEC-1891',
+    SouthAttleboro = 'place-NEC-1919',
+    Attleboro = 'place-NEC-1969',
+    Mansfield = 'place-NEC-2040',
+    Sharon = 'place-NEC-2108',
+    CantonJunction = 'place-NEC-2139',
+    Route128 = 'place-NEC-2173',
+}
+
+export const crworcesterLine: Line = {
+    name: 'Worcester',
+    abbreviation: 'FW',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Worcester': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Worcester,
+                    end: commuterRailStations.SouthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crfairmountLine: Line = {
+    name: 'Fairmount',
+    abbreviation: 'FM',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Fairmount': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Readville,
+                    end: commuterRailStations.SouthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crfitchburgLine: Line = {
+    name: 'Fitchburg',
+    abbreviation: 'FB',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Fitchburg': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Wachusett,
+                    end: commuterRailStations.NorthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crkingstonLine: Line = {
+    name: 'Kingston',
+    abbreviation: 'KL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Kingston': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Kingston,
+                    end: commuterRailStations.SouthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crLowellLine: Line = {
+    name: 'Lowell',
+    abbreviation: 'LL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Lowell': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Lowell,
+                    end: commuterRailStations.NorthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crNeedhamLine: Line = {
+    name: 'Needham',
+    abbreviation: 'NL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Needham': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.NeedhamHeights,
+                    end: commuterRailStations.SouthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crGreenbushLine: Line = {
+    name: 'Greenbush',
+    abbreviation: 'GL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Greenbush': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Greenbush,
+                    end: commuterRailStations.SouthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+export const crHaverillLine: Line = {
+    name: 'Haverhill',
+    abbreviation: 'HL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    fixedTrainLabelPosition: 'right',
+    routes: {
+        'CR-Haverhill': {
+            shape: [
+                start(0, 0, 90),
+                stationRange({
+                    start: commuterRailStations.Haverhill,
+                    end: commuterRailStations.NorthStation,
+                    commands: [line(150)],
+                }),
+            ],
+        },
+    },
+};
+
+const franklinShared: LineShape[] = [
+    start(0, 0, 90),
+    stationRange({
+        stations: [
+            commuterRailStations.SouthStation,
+            commuterRailStations.BackBay,
+            commuterRailStations.Ruggles,
+            commuterRailStations.ForestHills,
+            commuterRailStations.HydePark,
+            commuterRailStations.Readville,
+            commuterRailStations.Endicott,
+            commuterRailStations.DedhamCorporateCenter,
+            commuterRailStations.Islington,
+            commuterRailStations.NorwoodDepot,
+            commuterRailStations.NorwoodCentral,
+            commuterRailStations.WindsorGardens,
+        ],
+        commands: [line(120)],
+    }),
+];
+
+const franklinA: LineShape[] = [
+    ...franklinShared,
+    wiggle(30, -20),
+    stationRange({
+        stations: [
+            commuterRailStations.Walpole,
+            commuterRailStations.Norfolk,
+            commuterRailStations.Franklin,
+            commuterRailStations.ForgePark,
+        ],
+        commands: [line(50)],
+    }),
+];
+
+const franklinB: LineShape[] = [
+    ...franklinShared,
+    wiggle(30, 20),
+    stationRange({
+        stations: [commuterRailStations.Foxboro],
+        commands: [line(15)],
+    }),
+];
+
+export const crFranklinLine: Line = {
+    name: 'Franklin',
+    abbreviation: 'FL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    routes: {
+        'CR-Franklin-A': {
+            derivedFromRouteId: 'CR-Franklin',
+            shape: franklinA,
+        },
+        'CR-Franklin-B': {
+            derivedFromRouteId: 'CR-Franklin',
+            shape: franklinB,
+        },
+    },
+};
+
+const providenceShared: LineShape[] = [
+    start(0, 0, 90),
+    stationRange({
+        stations: [
+            commuterRailStations.SouthStation,
+            commuterRailStations.BackBay,
+            commuterRailStations.Ruggles,
+            commuterRailStations.ForestHills,
+            commuterRailStations.HydePark,
+            commuterRailStations.Route128,
+            commuterRailStations.CantonJunction,
+        ],
+        commands: [line(120)],
+    }),
+];
+
+const providenceA: LineShape[] = [
+    ...providenceShared,
+    wiggle(30, -20),
+    stationRange({
+        stations: [commuterRailStations.CantonCenter, commuterRailStations.Stoughton],
+        commands: [line(50)],
+    }),
+];
+
+const providenceB: LineShape[] = [
+    ...providenceShared,
+    wiggle(30, 20),
+    stationRange({
+        stations: [
+            commuterRailStations.Sharon,
+            commuterRailStations.Mansfield,
+            commuterRailStations.Attleboro,
+            commuterRailStations.SouthAttleboro,
+            commuterRailStations.Pawtucket,
+            commuterRailStations.Providence,
+            commuterRailStations.TFGreen,
+            commuterRailStations.WickfordJunction,
+        ],
+        commands: [line(50)],
+    }),
+];
+
+export const crProvidenceLine: Line = {
+    name: 'Providence',
+    abbreviation: 'PL',
+    color: '#c276b1ff',
+    colorSecondary: '#80276C',
+    getStationLabelPosition: () => 'right',
+    routes: {
+        'CR-Providence-A': {
+            derivedFromRouteId: 'CR-Providence',
+            shape: providenceA,
+        },
+        'CR-Providence-B': {
+            derivedFromRouteId: 'CR-Providence',
+            shape: providenceB,
+        },
+    },
+};

--- a/src/main.css
+++ b/src/main.css
@@ -169,6 +169,23 @@ a {
     width: 100%;
 }
 
+.separated-line-tabs {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+.separated-line-tabs .subway-tabs,
+.separated-line-tabs .commuter-rail-tabs {
+    display: flex;
+    justify-content: center;
+}
+
+.separated-line-tabs .commuter-rail-tabs {
+    margin-top: 5px;
+}
+
 @media (pointer: none) {
     .tab-picker > .tab:focus {
         outline: none;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,19 @@
-export type LineName = 'Green' | 'Red' | 'Orange' | 'Blue' | 'Mattapan';
+export type LineName =
+    | 'Green'
+    | 'Red'
+    | 'Orange'
+    | 'Blue'
+    | 'Mattapan'
+    | 'Worcester'
+    | 'Fairmount'
+    | 'Fitchburg'
+    | 'Franklin'
+    | 'Greenbush'
+    | 'Haverhill'
+    | 'Kingston'
+    | 'Lowell'
+    | 'Needham'
+    | 'Providence';
 
 export interface Line {
     name: LineName;
@@ -76,6 +91,7 @@ export interface Train {
     tripId: string;
     updatedAt: string;
     isPrideCar: boolean;
+    isHeritageCar: boolean;
     speed: number | null;
 }
 
@@ -125,7 +141,7 @@ export interface Pair {
     train: Train;
 }
 
-export type VehicleCategory = 'vehicles' | 'new_vehicles' | 'old_vehicles' | 'pride';
+export type VehicleCategory = 'vehicles' | 'new_vehicles' | 'old_vehicles' | 'pride' | 'heritage';
 
 export interface Prediction {
     departure_time: Date;


### PR DESCRIPTION
## Motivation

This is to add support for tracking Commuter Rail Lines, especially with the release of the "heritage" trains. In the future we could also track the rollout of BEMUs. But for now it is just meant to support local train spotters. 

## Changes

Added support for:

- Worcester
- Fairmount
- Fitchburg
- Franklin
- Greenbush
- Haverhill
- Kingston
- Lowell
- Needham
- Providence


The UI needs some polishing, which is why this is a draft PR for now. It also may be worth aggregating lines where possible such as the "Old Colony" lines or similar. 

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
