### PR TITLE
Add caching where doable to reduce server load

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,8 @@ if (typeof window !== 'undefined') {
 export const APP_DATA_BASE_PATH = FRONTEND_TO_BACKEND_MAP[domain] || '';
 
 // Time in milliseconds
+export const ONE_DAY = 24 * 60 * 60 * 1000;
 export const ONE_HOUR = 60 * 60 * 1000;
 export const FIVE_MINUTES = 5 * 60 * 1000;
 export const TEN_SECONDS = 10 * 1000;
+export const FIFTEEN_SECONDS = 15 * 1000;

--- a/src/hooks/usePrediction.ts
+++ b/src/hooks/usePrediction.ts
@@ -1,4 +1,4 @@
-import { APP_DATA_BASE_PATH, TEN_SECONDS } from '../constants';
+import { APP_DATA_BASE_PATH, FIFTEEN_SECONDS } from '../constants';
 import { useQuery } from '@tanstack/react-query';
 
 const getPrediction = (tripId: string | null, stopId: string) => {
@@ -16,7 +16,7 @@ export const usePrediction = (tripId: string | null, stopId: string) => {
         queryKey: ['getPrediction', tripId, stopId],
         queryFn: () => getPrediction(tripId, stopId),
         enabled: !!tripId,
-        staleTime: TEN_SECONDS,
+        staleTime: FIFTEEN_SECONDS,
     });
 
     return prediction;


### PR DESCRIPTION
## Motivation

Reduce calls to API gateway, which will lower cost and server load (as well as local web traffic usage) and will make the page seem faster to users

## Changes

- Add day and week cache to basically static data
- Increase from 10s refresh intervals to 15s to reduce API gateway load without meaningfully impacting usability
- Add cache to other calls both backend and frontend to reduce extra calls

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
