### PR TITLE
feat: Add holiday train filter with snowflake indicator

### DIFF
--- a/server/chalicelib/mbta_api.py
+++ b/server/chalicelib/mbta_api.py
@@ -127,6 +127,7 @@ async def vehicle_data_for_routes(route_ids):
             is_new = fleet.vehicle_array_is_new(custom_route, vehicle["label"].split("-"))
 
             is_pride_car = any(carriage.get("label") == "3706" for carriage in vehicle["carriages"])
+            is_holiday_car = any(carriage.get("label") in ["3908", "3917"] for carriage in vehicle["carriages"])
 
             vehicles_to_display.append(
                 {
@@ -144,6 +145,7 @@ async def vehicle_data_for_routes(route_ids):
                     "carriages": vehicle["carriages"],
                     "updatedAt": vehicle["updated_at"],
                     "isPrideCar": is_pride_car,
+                    "isHolidayCar": is_holiday_car,
                     "speed": vehicle["speed"],
                 }
             )

--- a/src/components/CategoryTabPicker.tsx
+++ b/src/components/CategoryTabPicker.tsx
@@ -10,6 +10,7 @@ const trainTypes: TrainCategory[] = [
     { key: 'new_vehicles', label: 'New' },
     { key: 'vehicles', label: 'All' },
     { key: 'pride', label: 'Pride' },
+    { key: 'holiday', label: 'Holiday' },
 ];
 
 interface CategoryTabPickerProps {
@@ -44,6 +45,7 @@ export const CategoryTabPicker: React.FC<CategoryTabPickerProps> = ({ tabColor }
                 <div className="selected-indicator" ref={selectedIndicatorRef} />
 
                 {trainTypes.map((trainType) => {
+                    const isHoliday = trainType.key === 'holiday';
                     return (
                         <Tab
                             id={trainType.key}
@@ -57,9 +59,9 @@ export const CategoryTabPicker: React.FC<CategoryTabPickerProps> = ({ tabColor }
                             <div
                                 aria-label={trainType.key}
                                 className="icon age"
-                                style={{ backgroundColor: tabColor }}
+                                style={{ backgroundColor: isHoliday ? 'transparent' : tabColor }}
                             >
-                                {trainType.label.toUpperCase()}
+                                {isHoliday ? '❄️' : trainType.label.toUpperCase()}
                             </div>
                             <div className="label">trains</div>
                         </Tab>

--- a/src/components/Line.tsx
+++ b/src/components/Line.tsx
@@ -17,6 +17,7 @@ const AGE_WORD_MAP = new Map<VehicleCategory, string>([
     ['old_vehicles', ' old '],
     ['vehicles', ' '],
     ['pride', ' pride '],
+    ['holiday', ' holiday '],
 ]);
 
 interface LineProps {

--- a/src/components/TrainDisplay.tsx
+++ b/src/components/TrainDisplay.tsx
@@ -55,7 +55,7 @@ export const TrainDisplay = ({
     onFocus: () => void;
     onBlur: () => void;
 }) => {
-    const { direction, isPrideCar } = train;
+    const { direction, isPrideCar, isHolidayCar } = train;
 
     const { pathInterpolator, stations } = route;
 
@@ -108,7 +108,7 @@ export const TrainDisplay = ({
                     cy={0}
                     r={3.326}
                     fill={colors.train}
-                    stroke={!isPrideCar && isTracked ? 'white' : 'none'}
+                    stroke={!isPrideCar && !isHolidayCar && isTracked ? 'white' : 'none'}
                     textAnchor="middle"
                 />
                 {isPrideCar && (
@@ -134,6 +134,71 @@ export const TrainDisplay = ({
                                 transform={`rotate(-90)`}
                             />
                         ))}
+                    </g>
+                )}
+                {isHolidayCar && (
+                    <g>
+                        <animateTransform
+                            attributeName="transform"
+                            type="rotate"
+                            values="0 0 0;360 0 0"
+                            dur="8s"
+                            repeatCount="indefinite"
+                        />
+                        {/* Outer snowflake circle */}
+                        <circle
+                            cx={0}
+                            cy={0}
+                            r={3.326}
+                            fill="none"
+                            stroke="#00bfff"
+                            strokeWidth={0.6}
+                            opacity={0.8}
+                        />
+                        {/* Snowflake arms - 6 main points */}
+                        {[0, 60, 120, 180, 240, 300].map((angle) => (
+                            <g key={angle} transform={`rotate(${angle})`}>
+                                {/* Main arm */}
+                                <line
+                                    x1={0}
+                                    y1={0}
+                                    x2={0}
+                                    y2={-4}
+                                    stroke="#1e90ff"
+                                    strokeWidth={0.5}
+                                />
+                                {/* Side branches */}
+                                <line
+                                    x1={0}
+                                    y1={-2.5}
+                                    x2={1}
+                                    y2={-3.2}
+                                    stroke="#1e90ff"
+                                    strokeWidth={0.4}
+                                />
+                                <line
+                                    x1={0}
+                                    y1={-2.5}
+                                    x2={-1}
+                                    y2={-3.2}
+                                    stroke="#1e90ff"
+                                    strokeWidth={0.4}
+                                />
+                            </g>
+                        ))}
+                        {/* Subtle glow effect */}
+                        <circle
+                            cx={0}
+                            cy={0}
+                            r={3.326}
+                            fill="none"
+                            stroke="#87ceeb"
+                            strokeWidth={0.3}
+                            opacity={0.6}
+                            style={{
+                                filter: 'drop-shadow(0 0 1.5px rgba(30, 144, 255, 0.6))',
+                            }}
+                        />
                     </g>
                 )}
                 <polygon points={drawEquilateralTriangle(2)} fill={'white'} />

--- a/src/hooks/useMbtaApi.ts
+++ b/src/hooks/useMbtaApi.ts
@@ -42,6 +42,10 @@ const filterPride = (trains: Train[]) => {
     return trains.filter((train) => train.isPrideCar);
 };
 
+const filterHoliday = (trains: Train[]) => {
+    return trains.filter((train) => train.isHolidayCar);
+};
+
 const filterTrains = (trains: Train[], vehiclesAge: VehicleCategory) => {
     if (vehiclesAge === 'new_vehicles') {
         return filterNew(trains);
@@ -49,6 +53,8 @@ const filterTrains = (trains: Train[], vehiclesAge: VehicleCategory) => {
         return filterOld(trains);
     } else if (vehiclesAge === 'pride') {
         return filterPride(trains);
+    } else if (vehiclesAge === 'holiday') {
+        return filterHoliday(trains);
     }
     return trains;
 };

--- a/src/main.css
+++ b/src/main.css
@@ -265,6 +265,55 @@ a {
     }
 }
 
+.tab-picker > .tab[id='holiday'] > .age {
+    background: linear-gradient(
+        135deg,
+        #1e90ff 0%,
+        #00bfff 50%,
+        #1e90ff 100%
+    );
+    position: relative;
+    overflow: hidden;
+}
+
+.tab-picker > .tab[id='holiday'] > .age::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: linear-gradient(
+        135deg,
+        transparent 25%,
+        rgba(255, 255, 255, 0.6) 50%,
+        transparent 75%
+    );
+    animation: frostGlow 3s ease-in-out infinite;
+    pointer-events: none;
+}
+
+@keyframes frostGlow {
+    0% {
+        transform: translateX(-100%) translateY(-100%) rotate(0deg);
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        transform: translateX(100%) translateY(100%) rotate(-45deg);
+        opacity: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tab-picker > .tab[id='holiday'] > .age::before {
+        animation: none;
+        opacity: 0;
+    }
+}
+
 .tab-picker > .tab > .label {
     margin: 0px 0.5em;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface Train {
     tripId: string;
     updatedAt: string;
     isPrideCar: boolean;
+    isHolidayCar: boolean;
     speed: number | null;
 }
 
@@ -125,7 +126,7 @@ export interface Pair {
     train: Train;
 }
 
-export type VehicleCategory = 'vehicles' | 'new_vehicles' | 'old_vehicles' | 'pride';
+export type VehicleCategory = 'vehicles' | 'new_vehicles' | 'old_vehicles' | 'pride' | 'holiday';
 
 export interface Prediction {
     departure_time: Date;


### PR DESCRIPTION
<img width="524" height="308" alt="Screenshot 2025-12-13 at 7 42 02 PM" src="https://github.com/user-attachments/assets/c80b04bf-14bc-4518-bafc-6168d3fe1509" />


- Add `isHolidayCar` property to Track trains with carriage labels 3908 and 3917
- Add Holiday category button (❄️ emoji) to CategoryTabPicker
- Implement holiday train filtering logic in useMbtaApi
- Add snowflake-shaped visual indicator for holiday trains on map
  - Blue snowflake design with rotating animation
  - Subtle glow effect for "magical appearance"
- Add snowflake emoji button styling with frostGlow animation
- Add holiday category to empty state message handling

# Motivation

The most wonderful time of the year. 
