### PR TITLE
Add Orange line holiday train set car numbers

### DIFF
--- a/server/chalicelib/mbta_api.py
+++ b/server/chalicelib/mbta_api.py
@@ -127,7 +127,7 @@ async def vehicle_data_for_routes(route_ids):
             is_new = fleet.vehicle_array_is_new(custom_route, vehicle["label"].split("-"))
 
             is_pride_car = any(carriage.get("label") == "3706" for carriage in vehicle["carriages"])
-            is_holiday_car = any(carriage.get("label") in ["3908", "3917"] for carriage in vehicle["carriages"])
+            is_holiday_car = any(carriage.get("label") in ["3908", "3917", "1524", "1525", "1531", "1530", "1529", "1528"] for carriage in vehicle["carriages"])
 
             vehicles_to_display.append(
                 {


### PR DESCRIPTION
## Motivation

In addition to the holiday wrapped Green line set 3908-3917 the Orange line recently received a holiday wrap as well, this PR adds those car numbers to the tracker.

## Changes

<img width="3726" height="2010" alt="image" src="https://github.com/user-attachments/assets/264a329a-b49c-4404-9dc5-e780c2de5e37" />

## Testing Instructions

If a set with 1524, 1525, 1531, 1530, 1529, or 1528 is active it should appear in the holiday style on the tracker.
