### PR TITLE
feat: add data about undelivered Type 9s for Mattapan

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Shows new MBTA Orange, Red, and Green Line trains as they come into service.
 
 ## Install & Run
 Dependencies:
-- `node 22.x` (with `npm 10.x`)
 - `python 3.13`
 - [`uv`](https://docs.astral.sh/uv/)
   - Ensure `uv` is using the correct Python version by running `uv venv --python 3.13`
+- `node 22.x` (with `npm 10.x`)
+  - If you are using `nvm` ensure it is using the correct Node version by running `nvm version`
 
 Run:
 - `$ npm install`

--- a/src/static_data.json
+++ b/src/static_data.json
@@ -31,6 +31,8 @@
     "Mattapan": {
         "totalActive": 7,
         "totalInactive": 3,
+        "totalNewDelivered": 0,
+        "totalNewUndelivered": 24,
         "programLink": "https://www.mbta.com/projects/mattapan-line-program"
     },
     "Sources": {


### PR DESCRIPTION
The Type 10s for the Green Line are on the way and the
T has commited to using the Type 9s on the Mattapan Line

While this will play out over a matter of years not months
going ahead and adding the data since we already know the
number of Type 9s and we are linking to the project page now