### PR TITLE
chore: update dependabot to manage pip ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
       interval: "weekly"


### PR DESCRIPTION
start chipping away at security vulnerabilities