### PR TITLE
chore: add uv ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
ensures that `uv.lock` is kept up to date in addition to `pyproject.toml`